### PR TITLE
Support viewing and playing albums

### DIFF
--- a/src/cli/gakki/cli/input.cljs
+++ b/src/cli/gakki/cli/input.cljs
@@ -1,0 +1,22 @@
+(ns gakki.cli.input
+  (:require [applied-science.js-interop :as j]
+            [ink :as k]))
+
+(def ^:private keyword-dispatchables
+  [:upArrow :downArrow :leftArrow :rightArrow
+   :pageDown :pageUp :return :escape :tab :backspace :delete])
+
+(def ^:private keyword-renames
+  {:upArrow :up
+   :downArrow :down
+   :leftArrow :left
+   :rightArrow :right
+   :pageUp :page-up
+   :pageDown :page-down})
+
+(defn use-input [f]
+  (k/useInput
+    (fn input-dispatcher [input k]
+      (let [kw (some #(when (j/get k %) %) keyword-dispatchables)
+            kw (get keyword-renames kw kw)]
+        (f (or kw input))))))

--- a/src/cli/gakki/components/limited-text.cljs
+++ b/src/cli/gakki/components/limited-text.cljs
@@ -1,0 +1,25 @@
+(ns gakki.components.limited-text
+  (:require [applied-science.js-interop :as j]
+            [ink :as k]
+            ["react" :as react]))
+
+(defn- limiter [{:keys [max-width] :as opts} & children]
+  (let [rf (react/useRef)
+        [measured-width set-measured-width!] (react/useState)]
+    (react/useEffect
+      (fn []
+        (when-let [node (.-current rf)]
+          (j/let [^:js {:keys [width]} (k/measureElement node)]
+            (set-measured-width! width)))))
+
+    [:> k/Box {:ref rf
+               :width (when measured-width
+                        (min max-width measured-width))}
+     (into [:> k/Text opts] children)]))
+
+(defn limited-text [{:keys [_max-width] :as opts} & children]
+  (let [opts (update opts :wrap (fn [provided]
+                                  (if (nil? provided)
+                                    :truncate-end
+                                    provided)))]
+    (into [:f> limiter opts] children)))

--- a/src/cli/gakki/views.cljs
+++ b/src/cli/gakki/views.cljs
@@ -2,12 +2,14 @@
   (:require [archetype.util :refer [<sub]]
             [gakki.views.auth :as auth]
             [gakki.views.auth.ytm :as auth-ytm]
+            [gakki.views.album :as album]
             [gakki.views.home :as home]))
 
 (def ^:private pages
   {:home #'home/view
    :auth #'auth/view
    :auth/ytm #'auth-ytm/view
+   :album #'album/view
    })
 
 (defn main []

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -1,0 +1,34 @@
+(ns gakki.views.album
+  (:require [applied-science.js-interop :as j]
+            [archetype.util :refer [<sub >evt]]
+            ["ink" :as k]
+            [gakki.components.player-mini :refer [player-mini]]
+            [gakki.components.scrollable :refer [vertical-list]]
+            [gakki.theme :as theme]))
+
+(defn track-row [track]
+  [:> k/Text (:title track)])
+
+(defn view [album-id]
+  (k/useInput
+    (fn [_input k]
+      (when (j/get k :escape)
+        (>evt [:navigate! [:home]]))))
+
+  (let [album (<sub [:album album-id])]
+    [:> k/Box {:flex-direction :column
+               :border-color theme/text-color-on-background
+               :border-style :round
+               :padding-x 1}
+     [player-mini]
+
+     [:> k/Text {:color theme/header-color-on-background}
+      (:title album)]
+     [:> k/Text {:color theme/text-color-on-background}
+      (:description album)]
+
+     [vertical-list
+      :items (:items album)
+      :follow-selected? true
+      :render track-row]
+     ]))

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -25,10 +25,18 @@
      [:> k/Box {:flex-direction :row
                 :justify-content :space-between
                 :padding-bottom 1}
-      [:> k/Text {:color theme/text-color-disabled}
-       "Albums / "]
-      [:> k/Text {:color theme/header-color-on-background}
-       (:title album)]
+      [:> k/Box {:flex-direction :row}
+       [:> k/Text {:color theme/text-color-disabled}
+        "Albums / "]
+
+       [:> k/Text {:color theme/header-color-on-background}
+        (:title album)]
+
+       [:> k/Text {:color theme/text-color-disabled} " / "]
+
+       [:> k/Text {:color theme/text-color-on-background}
+        (:artist album)]]
+
       [player-mini]]
 
      [:> k/Text {:color theme/text-color-on-background}

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -1,7 +1,7 @@
 (ns gakki.views.album
-  (:require [applied-science.js-interop :as j]
-            [archetype.util :refer [<sub >evt]]
+  (:require [archetype.util :refer [<sub >evt]]
             ["ink" :as k]
+            [gakki.cli.input :refer [use-input]]
             [gakki.components.player-mini :refer [player-mini]]
             [gakki.components.scrollable :refer [vertical-list]]
             [gakki.theme :as theme]))
@@ -10,10 +10,11 @@
   [:> k/Text (:title track)])
 
 (defn view [album-id]
-  (k/useInput
-    (fn [_input k]
-      (when (j/get k :escape)
-        (>evt [:navigate! [:home]]))))
+  (use-input
+    (fn [k]
+      (case k
+        :escape (>evt [:navigate! [:home]])
+        nil)))
 
   (let [album (<sub [:album album-id])]
     [:> k/Box {:flex-direction :column

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -27,6 +27,36 @@
                 {:color theme/text-color-on-background})
     " " title]])
 
+(defn- header [album]
+  [:> k/Box {:flex-direction :row
+             :justify-content :space-between
+             :padding-bottom 1}
+   [:> k/Box {:flex-direction :row}
+    [:> k/Text {:color theme/text-color-disabled}
+     "Albums / "]
+
+    [:> k/Text {:color theme/header-color-on-background
+                :underline true}
+     (:title album)]
+
+    [:> k/Text {:color theme/text-color-disabled} " / "]
+
+    [:> k/Text {:color theme/text-color-on-background}
+     (:artist album)]]
+
+   [player-mini]])
+
+(defn- description [album]
+  (when-not (empty? (:description album))
+    [:<>
+     [:> k/Text {:color theme/text-color-on-background}
+      (let [desc (:description album)]
+        (if (<= (count desc) max-description-length)
+          desc
+          (str (subs desc 0 (dec max-description-length))
+               figures/ellipsis)))]
+     [:> k/Text " "]]))
+
 (defn view [album-id]
   (r/with-let [state (r/atom nil)]
     (let [album (<sub [:album album-id])
@@ -57,36 +87,13 @@
                  :border-color theme/text-color-on-background
                  :border-style :round
                  :padding-x 1}
-       [:> k/Box {:flex-direction :row
-                  :justify-content :space-between
-                  :padding-bottom 1}
-        [:> k/Box {:flex-direction :row}
-         [:> k/Text {:color theme/text-color-disabled}
-          "Albums / "]
+       [header album]
 
-         [:> k/Text {:color theme/header-color-on-background
-                     :underline true}
-          (:title album)]
-
-         [:> k/Text {:color theme/text-color-disabled} " / "]
-
-         [:> k/Text {:color theme/text-color-on-background}
-          (:artist album)]]
-
-        [player-mini]]
-
-       (when-not (empty? (:description album))
-         [:<>
-          [:> k/Text {:color theme/text-color-on-background}
-           (let [desc (:description album)]
-             (if (<= (count desc) max-description-length)
-               desc
-               (str (subs desc 0 (dec max-description-length))
-                    figures/ellipsis)))]
-          [:> k/Text " "]])
+       [description album]
 
        [vertical-list
         :items items
         :follow-selected? true
+        :per-page 10
         :render track-row]
        ])))

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -10,13 +10,14 @@
   [:> k/Text (:title track)])
 
 (defn view [album-id]
-  (use-input
-    (fn [k]
-      (case k
-        :escape (>evt [:navigate! [:home]])
-        nil)))
-
   (let [album (<sub [:album album-id])]
+    (use-input
+      (fn [k]
+        (case k
+          "P" (>evt [:player/play-items (:items album)])
+          :escape (>evt [:navigate! [:home]])
+          nil)))
+
     [:> k/Box {:flex-direction :column
                :border-color theme/text-color-on-background
                :border-style :round

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -20,10 +20,15 @@
                :border-color theme/text-color-on-background
                :border-style :round
                :padding-x 1}
-     [player-mini]
+     [:> k/Box {:flex-direction :row
+                :justify-content :space-between
+                :padding-bottom 1}
+      [:> k/Text {:color theme/text-color-disabled}
+       "Albums / "]
+      [:> k/Text {:color theme/header-color-on-background}
+       (:title album)]
+      [player-mini]]
 
-     [:> k/Text {:color theme/header-color-on-background}
-      (:title album)]
      [:> k/Text {:color theme/text-color-on-background}
       (:description album)]
 

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -4,11 +4,14 @@
             ["ink" :as k]
             [reagent.core :as r]
             [gakki.cli.input :refer [use-input]]
+            [gakki.components.limited-text :refer [limited-text]]
             [gakki.components.player-mini :refer [player-mini]]
             [gakki.components.scrollable :refer [vertical-list]]
             [gakki.theme :as theme]))
 
 (def max-description-length 280)
+(def max-album-title-length 20)
+(def max-artist-name-length 20)
 
 (defn- length-wrapped [f length]
   (fn wrapped [v]
@@ -35,13 +38,15 @@
     [:> k/Text {:color theme/text-color-disabled}
      "Albums / "]
 
-    [:> k/Text {:color theme/header-color-on-background
-                :underline true}
+    [limited-text {:color theme/header-color-on-background
+                   :max-width max-album-title-length
+                   :underline true}
      (:title album)]
 
     [:> k/Text {:color theme/text-color-disabled} " / "]
 
-    [:> k/Text {:color theme/text-color-on-background}
+    [limited-text {:color theme/text-color-on-background
+                   :max-width max-artist-name-length}
      (:artist album)]]
 
    [player-mini]])

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -1,49 +1,92 @@
 (ns gakki.views.album
   (:require [archetype.util :refer [<sub >evt]]
+            ["figures" :as figures]
             ["ink" :as k]
+            [reagent.core :as r]
             [gakki.cli.input :refer [use-input]]
             [gakki.components.player-mini :refer [player-mini]]
             [gakki.components.scrollable :refer [vertical-list]]
             [gakki.theme :as theme]))
 
-(defn track-row [track]
-  [:> k/Text (:title track)])
+(def max-description-length 280)
+
+(defn- length-wrapped [f length]
+  (fn wrapped [v]
+    (mod (f v) length)))
+
+(defn track-row [{:keys [title selected?]}]
+  [:> k/Box {:flex-direction :row}
+   (if selected?
+     (when selected?
+       [:> k/Text
+        {:color theme/text-color-on-background}
+        figures/pointer])
+     [:> k/Text " "])
+
+   [:> k/Text (when selected?
+                {:color theme/text-color-on-background})
+    " " title]])
 
 (defn view [album-id]
-  (let [album (<sub [:album album-id])]
-    (use-input
-      (fn [k]
-        (case k
-          "P" (>evt [:player/play-items (:items album)])
-          :escape (>evt [:navigate! [:home]])
-          nil)))
+  (r/with-let [state (r/atom nil)]
+    (let [album (<sub [:album album-id])
+          items (:items album)
+          items (if-let [selected-index (:selected-index @state)]
+                  (assoc-in items [selected-index :selected?] true)
+                  items)]
+      (use-input
+        (fn [k]
+          (case k
+            "j" (swap! state update :selected-index (length-wrapped
+                                                      (fnil inc -1)
+                                                      (count items)))
+            "k" (swap! state update :selected-index (length-wrapped
+                                                      (fnil dec 1)
+                                                      (count items)))
 
-    [:> k/Box {:flex-direction :column
-               :border-color theme/text-color-on-background
-               :border-style :round
-               :padding-x 1}
-     [:> k/Box {:flex-direction :row
-                :justify-content :space-between
-                :padding-bottom 1}
-      [:> k/Box {:flex-direction :row}
-       [:> k/Text {:color theme/text-color-disabled}
-        "Albums / "]
+            :return (if-let [index (:selected-index @state)]
+                      (>evt [:player/play-items (:items album)
+                             index])
+                      (>evt [:player/play-items (:items album)]))
+            :escape (if @state
+                      (reset! state nil)
+                      (>evt [:navigate! [:home]]))
+            nil)))
 
-       [:> k/Text {:color theme/header-color-on-background}
-        (:title album)]
+      [:> k/Box {:flex-direction :column
+                 :border-color theme/text-color-on-background
+                 :border-style :round
+                 :padding-x 1}
+       [:> k/Box {:flex-direction :row
+                  :justify-content :space-between
+                  :padding-bottom 1}
+        [:> k/Box {:flex-direction :row}
+         [:> k/Text {:color theme/text-color-disabled}
+          "Albums / "]
 
-       [:> k/Text {:color theme/text-color-disabled} " / "]
+         [:> k/Text {:color theme/header-color-on-background
+                     :underline true}
+          (:title album)]
 
-       [:> k/Text {:color theme/text-color-on-background}
-        (:artist album)]]
+         [:> k/Text {:color theme/text-color-disabled} " / "]
 
-      [player-mini]]
+         [:> k/Text {:color theme/text-color-on-background}
+          (:artist album)]]
 
-     [:> k/Text {:color theme/text-color-on-background}
-      (:description album)]
+        [player-mini]]
 
-     [vertical-list
-      :items (:items album)
-      :follow-selected? true
-      :render track-row]
-     ]))
+       (when-not (empty? (:description album))
+         [:<>
+          [:> k/Text {:color theme/text-color-on-background}
+           (let [desc (:description album)]
+             (if (<= (count desc) max-description-length)
+               desc
+               (str (subs desc 0 (dec max-description-length))
+                    figures/ellipsis)))]
+          [:> k/Text " "]])
+
+       [vertical-list
+        :items items
+        :follow-selected? true
+        :render track-row]
+       ])))

--- a/src/cli/gakki/views/auth.cljs
+++ b/src/cli/gakki/views/auth.cljs
@@ -1,11 +1,11 @@
 (ns gakki.views.auth
   (:require [archetype.util :refer [<sub >evt]]
             [reagent.core :as r]
-            [applied-science.js-interop :as j]
             ["figures" :as figures]
             ["ink" :as k]
             [gakki.accounts :as accounts]
             [gakki.accounts.core :as ap]
+            [gakki.cli.input :refer [use-input]]
             [gakki.theme :as theme]))
 
 (defn- provider-row [selected-key k provider]
@@ -48,19 +48,17 @@
   (let [selected-key @selected-atom
         rotate! (partial rotate-provider providers)
         accounts (<sub [:accounts])]
-    (k/useInput
-      (fn [input k]
-        (case input
+    (use-input
+      (fn [k]
+        (case k
           ; Switch "selected" account:
           "j" (swap! selected-atom rotate! 1)
           "k" (swap! selected-atom rotate! -1)
 
-          (cond
-            (j/get k :escape)
-            (>evt [:navigate! [:home]])
+          :escape (>evt [:navigate! [:home]])
+          :return (>evt [:navigate! [(keyword "auth" selected-key)]])
 
-            (j/get k :return)
-            (>evt [:navigate! [(keyword "auth" selected-key)]])))))
+          nil)))
 
     [:> k/Box {:flex-direction :column
                :border-color theme/text-color-on-background

--- a/src/cli/gakki/views/home.cljs
+++ b/src/cli/gakki/views/home.cljs
@@ -1,16 +1,16 @@
 (ns gakki.views.home
-  (:require [applied-science.js-interop :as j]
-            [archetype.util :refer [<sub >evt]]
+  (:require [archetype.util :refer [<sub >evt]]
             ["figures" :as figures]
             ["ink" :as k]
             ["ink-spinner" :default Spinner]
+            [gakki.cli.input :refer [use-input]]
             [gakki.components.player-mini :refer [player-mini]]
             [gakki.components.scrollable :refer [horizontal-list
                                                  vertical-list]]
             [gakki.theme :as theme]))
 
-(defn- handle-input [input k]
-  (case input
+(defn- handle-input [k]
+  (case k
     "r" (>evt [:providers/refresh!])
 
     "j" (>evt [:home/navigate-categories :down])
@@ -23,11 +23,10 @@
     "[" (>evt [:player/volume-inc -1])
     "]" (>evt [:player/volume-inc 1])
 
-    (cond
-      (j/get k :return) (>evt [:home/open-selected])
+    :return (>evt [:home/open-selected])
 
-      :else (when goog.DEBUG
-              (println input k)))))
+    (when goog.DEBUG
+      (println k))))
 
 (defn- category-item [{:keys [title selected?]}]
   [:> k/Box {:width :20%
@@ -64,7 +63,7 @@
    [player-mini]])
 
 (defn view []
-  (k/useInput handle-input)
+  (use-input handle-input)
 
   (let [categories (<sub [:home/categories])]
     [:> k/Box {:flex-direction :column

--- a/src/core/gakki/accounts/core.cljs
+++ b/src/core/gakki/accounts/core.cljs
@@ -20,6 +20,10 @@
       [{:name \"Category Name\"
         :items []}]}")
 
+  (resolve-album
+    [this account album-id]
+    "Return a promise...")
+
   (resolve-playlist
     [this account playlist-id]
     "Return a promise..."))

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -161,8 +161,9 @@
 
   (p/let [result (do-resolve-album
                    (:ytm @(re-frame.core/subscribe [:accounts]))
-                   "MPREb_6zoi6tZGf72") ]
+                   "MPREb_XSoe2FaWnVW") ]
     (prn result)
     )
+
   )
 

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -114,6 +114,10 @@
      (->> (j/get data :content)
           (map ->playlist-item))}))
 
+(defn- do-resolve-album [account album-id]
+  (p/let [^YTMusic ytm (account->client account)]
+    (album/load ytm album-id)))
+
 (deftype YTMAccountProvider []
   IAccountProvider
   (get-name [_this] "YouTube Music")
@@ -129,12 +133,14 @@
     ; NOTE: this is pulled out to a separate fn to facilitate hot-reload dev
     (do-fetch-home account))
 
+  (resolve-album [_ account album-id]
+    (do-resolve-album account album-id))
+
   (resolve-playlist [_ account playlist-id]
     (do-resolve-playlist account playlist-id))
   )
 
 (comment
-
   (p/let [client (account->client
                    (:ytm @(re-frame.core/subscribe [:accounts])))
           result (-> client
@@ -153,12 +159,9 @@
     (js/console.log (js/JSON.stringify result nil 2))
     )
 
-  (p/let [client (account->client
-                   (:ytm @(re-frame.core/subscribe [:accounts])))
-          ;; result (-> client
-          ;;            (.getPlaylist "MPREb_6zoi6tZGf72"))
-          result (album/load client "MPREb_6zoi6tZGf72")
-          ]
+  (p/let [result (do-resolve-album
+                   (:ytm @(re-frame.core/subscribe [:accounts]))
+                   "MPREb_6zoi6tZGf72") ]
     (prn result)
     )
   )

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -4,7 +4,9 @@
             [promesa.core :as p]
             ["youtubish/dist/creds" :refer [cached OauthCredentialsManager]]
             ["ytmusic" :rename {YTMUSIC YTMusic}]
+            ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]
             [gakki.accounts.core :refer [IAccountProvider]]
+            [gakki.accounts.ytm.album :as album]
             [gakki.player.ytm :refer [youtube-id->playable]]))
 
 (def ^:private account->creds
@@ -130,3 +132,34 @@
   (resolve-playlist [_ account playlist-id]
     (do-resolve-playlist account playlist-id))
   )
+
+(comment
+
+  (p/let [client (account->client
+                   (:ytm @(re-frame.core/subscribe [:accounts])))
+          result (-> client
+                     (.getArtist "UCvInFYiyeAJOGEjhqJnyaMA"))]
+    (println result))
+
+  (p/let [client (account->client
+                   (:ytm @(re-frame.core/subscribe [:accounts])))
+          ;; result (-> client
+          ;;            (.getPlaylist "MPREb_6zoi6tZGf72"))
+          result (send-request (.-cookie client)
+                               #js {:id "MPREb_6zoi6tZGf72"
+                                    :type "ALBUM"
+                                    :endpoint "browse"})
+          ]
+    (js/console.log (js/JSON.stringify result nil 2))
+    )
+
+  (p/let [client (account->client
+                   (:ytm @(re-frame.core/subscribe [:accounts])))
+          ;; result (-> client
+          ;;            (.getPlaylist "MPREb_6zoi6tZGf72"))
+          result (album/load client "MPREb_6zoi6tZGf72")
+          ]
+    (prn result)
+    )
+  )
+

--- a/src/core/gakki/accounts/ytm/album.cljs
+++ b/src/core/gakki/accounts/ytm/album.cljs
@@ -57,7 +57,7 @@
      :radio-playlist-id (j/get album-entity :radioAutomixPlaylistId)
      :image-url (pick-thumbnail album-entity)
      :items (->> (j/get details-entity :tracks)
-                 (map (partial inflate-track state)))}))
+                 (mapv (partial inflate-track state)))}))
 
 (defn load [^YTMusic client id]
   (p/let [response (send-request (.-cookie client)

--- a/src/core/gakki/accounts/ytm/album.cljs
+++ b/src/core/gakki/accounts/ytm/album.cljs
@@ -52,8 +52,8 @@
      :description (j/get details-entity :description)
      :radio-playlist-id (j/get album-entity :radioAutomixPlaylistId)
      :image-url (pick-thumbnail album-entity)
-     :tracks (->> (j/get details-entity :tracks)
-                  (map (partial inflate-track state)))}))
+     :items (->> (j/get details-entity :tracks)
+                 (map (partial inflate-track state)))}))
 
 (defn load [^YTMusic client id]
   (p/let [response (send-request (.-cookie client)

--- a/src/core/gakki/accounts/ytm/album.cljs
+++ b/src/core/gakki/accounts/ytm/album.cljs
@@ -40,6 +40,7 @@
     {:id (j/get track-entity :videoId)
      :title (j/get track-entity :title)
      :kind :track
+     :provider :ytm
      :artist (j/get track-entity :artistNames)
      :image-url (pick-thumbnail track-entity)}))
 
@@ -49,6 +50,7 @@
     {:id (j/get album-entity :id)
      :title (j/get album-entity :title)
      :kind :album
+     :provider :ytm
      :description (j/get details-entity :description)
      :radio-playlist-id (j/get album-entity :radioAutomixPlaylistId)
      :image-url (pick-thumbnail album-entity)

--- a/src/core/gakki/accounts/ytm/album.cljs
+++ b/src/core/gakki/accounts/ytm/album.cljs
@@ -1,0 +1,68 @@
+(ns gakki.accounts.ytm.album
+  (:require [applied-science.js-interop :as j]
+            [promesa.core :as p]
+            ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]
+            ["ytmusic" :rename {YTMUSIC YTMusic}]))
+
+(defmulti ^:private apply-mutation (fn [_state mutation]
+                                     (j/get mutation :type)))
+
+(defmethod apply-mutation "ENTITY_MUTATION_TYPE_REPLACE"
+  [state mutation]
+  (j/let [^:js {id :entityKey payload :payload} mutation
+          entity-type (-> (js/Object.keys payload)
+                          first
+                          keyword)
+          entity (-> (j/get payload entity-type)
+                     (j/assoc! :type entity-type))]
+    (-> state
+        (assoc id entity)
+        (update entity-type (fnil conj []) id))))
+
+(defn apply-mutations
+  "Some YTM responses include 'framework updates' which update a bunch of 'entities'
+   by ID. This function takes a batch-update and returns a map of id -> entity"
+  ([^js mutations] (apply-mutations {} mutations))
+  ([initial-state ^js mutations]
+   (loop [state initial-state
+          mutations mutations]
+     (if-let [mutation (first mutations)]
+       (recur (apply-mutation state mutation)
+              (next mutations))
+       state))))
+
+(defn- pick-thumbnail [entity]
+  (when-let [thumb (first (j/get-in entity [:thumbnailDetails :thumbnails]))]
+    (j/get thumb :url)))
+
+(defn inflate-track [state track-id]
+  (let [track-entity (get state track-id)]
+    {:id (j/get track-entity :videoId)
+     :title (j/get track-entity :title)
+     :kind :track
+     :artist (j/get track-entity :artistNames)
+     :image-url (pick-thumbnail track-entity)}))
+
+(defn inflate-album [state album-id]
+  (let [album-entity (get state album-id)
+        details-entity (get state (j/get album-entity :details))]
+    {:id (j/get album-entity :id)
+     :title (j/get album-entity :title)
+     :kind :album
+     :description (j/get details-entity :description)
+     :radio-playlist-id (j/get album-entity :radioAutomixPlaylistId)
+     :image-url (pick-thumbnail album-entity)
+     :tracks (->> (j/get details-entity :tracks)
+                  (map (partial inflate-track state)))}))
+
+(defn load [^YTMusic client id]
+  (p/let [response (send-request (.-cookie client)
+                                 #js {:id id
+                                      :type "ALBUM"
+                                      :endpoint "browse"})
+          entities (apply-mutations (j/get-in response [:frameworkUpdates
+                                                        :entityBatchUpdate
+                                                        :mutations]))
+          album-id (->> entities :musicAlbumRelease first)]
+    (when album-id
+      (inflate-album entities album-id))))

--- a/src/core/gakki/accounts/ytm/album.cljs
+++ b/src/core/gakki/accounts/ytm/album.cljs
@@ -51,7 +51,9 @@
      :title (j/get album-entity :title)
      :kind :album
      :provider :ytm
+     ::entity album-entity
      :description (j/get details-entity :description)
+     :artist (j/get album-entity :artistDisplayName)
      :radio-playlist-id (j/get album-entity :radioAutomixPlaylistId)
      :image-url (pick-thumbnail album-entity)
      :items (->> (j/get details-entity :tracks)

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -126,9 +126,7 @@
         :song {:dispatch [::set-current-playable item]}
 
         :playlist (if-let [items (seq (:items item))]
-                    {:db (-> db
-                             (assoc-in [:player :queue] items))
-                     :dispatch [::set-current-playable (first items)]}
+                    {:dispatch [:player/play-items items]}
 
                     ; Unresolved playlist; fetch and resolve now:
                     {:providers/resolve-and-open [:playlist (:accounts db) item]})
@@ -148,6 +146,13 @@
     {:db (assoc-in db [entity-kind (:id entity)] entity)
      :fx [(when (= :action/open ?action)
             [:dispatch [:player/open entity]])]}))
+
+(reg-event-fx
+  :player/play-items
+  [trim-v (path :player :queue)]
+  (fn [_ [items]]
+    {:db items
+     :dispatch [::set-current-playable (first items)]}))
 
 (reg-event-fx
   ::set-current-playable

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -150,9 +150,15 @@
 (reg-event-fx
   :player/play-items
   [trim-v (path :player :queue)]
-  (fn [_ [items]]
-    {:db items
-     :dispatch [::set-current-playable (first items)]}))
+  (fn [_ [items ?selected-index]]
+    {:db (if (nil? ?selected-index)
+           items
+           (vec (concat
+                  (drop ?selected-index items)
+                  (take ?selected-index items))))
+     :dispatch [::set-current-playable (if (nil? ?selected-index)
+                                         (first items)
+                                         (nth items ?selected-index))]}))
 
 (reg-event-fx
   ::set-current-playable

--- a/src/core/gakki/native/macos.cljs
+++ b/src/core/gakki/native/macos.cljs
@@ -63,6 +63,7 @@
                  messages (keep parse-message parts)]
              (doseq [message messages]
                (try
+                 (println "HANDLE" message)
                  (handle-message message)
                  (catch :default e
                    (println "[err:native] Failed to handle " (str message)

--- a/src/core/gakki/native/macos.cljs
+++ b/src/core/gakki/native/macos.cljs
@@ -63,7 +63,6 @@
                  messages (keep parse-message parts)]
              (doseq [message messages]
                (try
-                 (println "HANDLE" message)
                  (handle-message message)
                  (catch :default e
                    (println "[err:native] Failed to handle " (str message)

--- a/src/core/gakki/player/pcm.cljs
+++ b/src/core/gakki/player/pcm.cljs
@@ -64,7 +64,8 @@
 
   (pause [_this]
     (let [{:keys [^RtAudio speaker, output-stream clear-timer]} @state]
-      (clear-timer)
+      (when clear-timer
+        (clear-timer))
       (swap! state dissoc :clear-timer)
 
       (when (and speaker output-stream)

--- a/src/core/gakki/player/remote.cljs
+++ b/src/core/gakki/player/remote.cljs
@@ -7,6 +7,7 @@
 
 (def ^:private writer (t/writer :json))
 (def ^:private reader (t/reader :json))
+(def ^:private debug-io? false)
 
 (defonce state (atom nil))
 
@@ -20,7 +21,7 @@
     existing
 
     (let [proc (fork "resources/player.js"
-                     #js {:stdio (if const/debug?
+                     #js {:stdio (if (and debug-io? const/debug?)
                                    "inherit"
                                    "ignore")})
           clear-state! (fn [e]

--- a/src/core/gakki/subs.cljs
+++ b/src/core/gakki/subs.cljs
@@ -100,3 +100,11 @@
                                          selected-item)
                                     (assoc item :selected? true)
                                     item)))))))))))
+
+
+; ======= entities ========================================
+
+(reg-sub
+  :album
+  (fn [db [_ id]]
+    (get-in db [:album id])))

--- a/src/test/gakki/accounts/ytm/album_test.cljs
+++ b/src/test/gakki/accounts/ytm/album_test.cljs
@@ -1,0 +1,36 @@
+(ns gakki.accounts.ytm.album-test
+  (:require [applied-science.js-interop :as j]
+            [cljs.test :refer-macros [deftest is testing]]
+            [gakki.accounts.ytm.album :refer [apply-mutations]]))
+
+(declare response-mutations)
+
+(deftest apply-mutations-test
+  (testing "Index album"
+    (let [state (apply-mutations response-mutations)]
+      (is (= ["track"]
+             (:musicTrack state))))))
+
+(def response-mutations
+  (j/lit
+    [{:entityKey "track"
+      :type "ENTITY_MUTATION_TYPE_REPLACE"
+      :payload
+      {:musicTrack
+       {:id "track",
+        :title "Sounds of Serenity",
+        :thumbnailDetails
+        {:thumbnails [{:url "thumb",
+                       :width 60,
+                       :height 60}]},
+        :artists ["artist"],
+        :artistNames "CHVRCHES",
+        :videoId "DAE0tpnwGEc",
+        :userDetails "user-details",
+        :albumRelease "album-release",
+        :albumTrackIndex "1",
+        :lengthMs "186644",
+        :contentRating {:explicitType
+                        "MUSIC_ENTITY_EXPLICIT_TYPE_NOT_EXPLICIT"},
+        :share "EgtEQUUwdHBud0dFYyBkKAE%3D"}
+       }}]))


### PR DESCRIPTION
- Add first, experimental album loading support
- Add basic support for viewing an album
- Tweak album layout slightly
- Add a new use-input method to wrap and simplify useInput
- Convert remaining legacy useInput to new use-input
- Add basic support for playing albums
- Ensure :provider is set on YTM albums and tracks
- Add artist information to the album
- Trim album description; support playing an album from a specific song
- Reorganize the album component + show more tracks per page
