### PR TITLE
Support rendering artist pages

### DIFF
--- a/src/cli/gakki/components/carousels.cljs
+++ b/src/cli/gakki/components/carousels.cljs
@@ -1,6 +1,8 @@
 (ns gakki.components.carousels
-  "Renders a sectional/carousel-based UI, like the Home page, or Artists"
-  (:require ["figures" :as figures]
+  "Renders a sectional/carousel-based UI, like the Home page, or Artists.
+   The data is automatically pulled from the `[:carousel/categories]` sub"
+  (:require [archetype.util :refer [<sub >evt]]
+            ["figures" :as figures]
             ["ink" :as k]
             [gakki.cli.input :refer [use-input]]
             [gakki.components.scrollable :refer [horizontal-list
@@ -30,23 +32,20 @@
     :items items
     :render category-item]])
 
-(defn carousels [& {:keys [categories
-                           navigate-categories!
-                           navigate-row!
-                           open-selected!]}]
+(defn carousels []
   (use-input
     (fn [k]
       (case k
-        "j" (navigate-categories! :down)
-        "k" (navigate-categories! :up)
-        "h" (navigate-row! :left)
-        "l" (navigate-row! :right)
+        "j" (>evt [:carousel/navigate-categories :down])
+        "k" (>evt [:carousel/navigate-categories :up])
+        "h" (>evt [:carousel/navigate-row :left])
+        "l" (>evt [:carousel/navigate-row :right])
 
-        :return (open-selected!)
+        :return (>evt [:carousel/open-selected])
         nil)))
 
   [vertical-list
-   :items categories
+   :items (<sub [:carousel/categories])
    :follow-selected? true
    :key-fn :title
    :render category-row])

--- a/src/cli/gakki/components/carousels.cljs
+++ b/src/cli/gakki/components/carousels.cljs
@@ -1,0 +1,52 @@
+(ns gakki.components.carousels
+  "Renders a sectional/carousel-based UI, like the Home page, or Artists"
+  (:require ["figures" :as figures]
+            ["ink" :as k]
+            [gakki.cli.input :refer [use-input]]
+            [gakki.components.scrollable :refer [horizontal-list
+                                                 vertical-list]]
+            [gakki.theme :as theme]))
+
+(defn- category-item [{:keys [title selected?]}]
+  [:> k/Box {:width :20%
+             :padding-x 1}
+   ; TODO Could we tint colors based on album art?
+   [:> k/Text
+    (when selected?
+      figures/pointer)
+    title]])
+
+(defn- category-row [{:keys [title items selected?]}]
+  [:> k/Box {:flex-direction :column
+             :padding-top 1}
+   [:> k/Text {:color theme/text-color-on-background}
+    (when selected?
+      figures/pointer)
+    title
+    [:> k/Text {:color theme/text-color-disabled}
+     " (" (count items) ")"]]
+   [horizontal-list
+    :follow-selected? selected?
+    :items items
+    :render category-item]])
+
+(defn carousels [& {:keys [categories
+                           navigate-categories!
+                           navigate-row!
+                           open-selected!]}]
+  (use-input
+    (fn [k]
+      (case k
+        "j" (navigate-categories! :down)
+        "k" (navigate-categories! :up)
+        "h" (navigate-row! :left)
+        "l" (navigate-row! :right)
+
+        :return (open-selected!)
+        nil)))
+
+  [vertical-list
+   :items categories
+   :follow-selected? true
+   :key-fn :title
+   :render category-row])

--- a/src/cli/gakki/components/header.cljs
+++ b/src/cli/gakki/components/header.cljs
@@ -1,0 +1,16 @@
+(ns gakki.components.header
+  (:require [archetype.util :refer [<sub]]
+            ["ink" :as k]
+            ["ink-spinner" :default Spinner]
+            [gakki.components.player-mini :refer [player-mini]]
+            [gakki.theme :as theme]))
+
+(defn header [& title]
+  [:> k/Box {:flex-direction :row
+             :justify-content :space-between}
+   (into
+     [:> k/Text {:color theme/header-color-on-background}
+      (when (<sub [:loading?])
+        [:> Spinner {:type "dots"}])]
+     title)
+   [player-mini]])

--- a/src/cli/gakki/views.cljs
+++ b/src/cli/gakki/views.cljs
@@ -1,8 +1,11 @@
 (ns gakki.views
   (:require [archetype.util :refer [<sub]]
+            [gakki.theme :as theme]
+            ["ink" :as k]
             [gakki.views.auth :as auth]
             [gakki.views.auth.ytm :as auth-ytm]
             [gakki.views.album :as album]
+            [gakki.views.artist :as artist]
             [gakki.views.home :as home]))
 
 (def ^:private pages
@@ -10,14 +13,25 @@
    :auth #'auth/view
    :auth/ytm #'auth-ytm/view
    :album #'album/view
+   :artist #'artist/view
    })
 
 (defn main []
   (let [accounts (<sub [:accounts])
         [page args] (<sub [:page])
-        page-form [:f> (get pages page) args]]
-    (if (or (seq accounts)
-            (= "auth" (namespace page)))
+        page-fn (get pages page)
+        page-form [:f> page-fn args]]
+    (cond
+      (not page-fn)
+      [:> k/Text
+       [:> k/Text {:background-color "red"} " ERROR "]
+       " No page registered for: "
+       [:> k/Text {:color theme/header-color-on-background}
+        (str [page args])]]
+
+      (or (seq accounts)
+          (= "auth" (namespace page)))
       page-form
 
+      :else
       [:f> auth/view])))

--- a/src/cli/gakki/views/artist.cljs
+++ b/src/cli/gakki/views/artist.cljs
@@ -1,0 +1,31 @@
+(ns gakki.views.artist
+  (:require [archetype.util :refer [>evt <sub]]
+            ["ink" :as k]
+            [gakki.cli.input :refer [use-input]]
+            [gakki.components.carousels :refer [carousels]]
+            [gakki.components.header :refer [header]]
+            [gakki.theme :as theme]))
+
+(defn view [artist-id]
+  (let [artist (<sub [:artist artist-id])]
+    (use-input
+      (fn [k]
+        (case k
+          :escape (>evt [:navigate/back!])
+          nil)))
+
+    [:> k/Box {:flex-direction :column
+               :border-color theme/text-color-on-background
+               :border-style :round
+               :padding-x 1}
+     [header
+      [:> k/Text {:color theme/text-color-disabled}
+       "Artists / "]
+      (:title artist)]
+
+     [:f> carousels
+      :categories (:categories artist)
+      :navigate-categories! identity ; TODO
+      :navigate-row! identity ; TODO
+      :open-selected! identity]])
+  )

--- a/src/cli/gakki/views/artist.cljs
+++ b/src/cli/gakki/views/artist.cljs
@@ -23,9 +23,4 @@
        "Artists / "]
       (:title artist)]
 
-     [:f> carousels
-      :categories (:categories artist)
-      :navigate-categories! identity ; TODO
-      :navigate-row! identity ; TODO
-      :open-selected! identity]])
-  )
+     [:f> carousels]]))

--- a/src/cli/gakki/views/home.cljs
+++ b/src/cli/gakki/views/home.cljs
@@ -37,8 +37,4 @@
              :padding-x 1}
    [header]
 
-   [:f> carousels
-    :categories (<sub [:home/categories])
-    :navigate-categories! #(>evt [:home/navigate-categories %])
-    :navigate-row! #(>evt [:home/navigate-row %])
-    :open-selected! #(>evt [:home/open-selected])]])
+   [:f> carousels]])

--- a/src/cli/gakki/views/home.cljs
+++ b/src/cli/gakki/views/home.cljs
@@ -1,56 +1,22 @@
 (ns gakki.views.home
   (:require [archetype.util :refer [<sub >evt]]
-            ["figures" :as figures]
             ["ink" :as k]
             ["ink-spinner" :default Spinner]
             [gakki.cli.input :refer [use-input]]
             [gakki.components.player-mini :refer [player-mini]]
-            [gakki.components.scrollable :refer [horizontal-list
-                                                 vertical-list]]
+            [gakki.components.carousels :refer [carousels]]
             [gakki.theme :as theme]))
 
 (defn- handle-input [k]
   (case k
     "r" (>evt [:providers/refresh!])
 
-    "j" (>evt [:home/navigate-categories :down])
-    "k" (>evt [:home/navigate-categories :up])
-    "h" (>evt [:home/navigate-row :left])
-    "l" (>evt [:home/navigate-row :right])
-
     ; TODO: these should probably be global...
     "p" (>evt [:player/play-pause])
     "[" (>evt [:player/volume-inc -1])
     "]" (>evt [:player/volume-inc 1])
 
-    :return (>evt [:home/open-selected])
-
-    (when goog.DEBUG
-      (println k))))
-
-(defn- category-item [{:keys [title selected?]}]
-  [:> k/Box {:width :20%
-             :padding-x 1}
-   [:> k/Text
-    (when selected?
-      figures/pointer)
-    title]])
-
-(defn- category-row [{:keys [title items selected?]}]
-  ; TODO Could we tint colors based on album art?
-  [:> k/Box {:flex-direction :column
-             :padding-top 1}
-   [:> k/Text {:color theme/text-color-on-background}
-    (when selected?
-      figures/pointer)
-    title
-    [:> k/Text {:color theme/text-color-disabled}
-     " (" (count items) ")"]]
-   [horizontal-list
-    :follow-selected? selected?
-    :items items
-    :render category-item]
-   ])
+    nil))
 
 (defn- header []
   [:> k/Box {:flex-direction :row
@@ -65,16 +31,14 @@
 (defn view []
   (use-input handle-input)
 
-  (let [categories (<sub [:home/categories])]
-    [:> k/Box {:flex-direction :column
-               :border-color theme/text-color-on-background
-               :border-style :round
-               :padding-x 1}
-     [header]
+  [:> k/Box {:flex-direction :column
+             :border-color theme/text-color-on-background
+             :border-style :round
+             :padding-x 1}
+   [header]
 
-     [vertical-list
-      :items categories
-      :follow-selected? true
-      :key-fn :title
-      :render category-row]
-     ]))
+   [:f> carousels
+    :categories (<sub [:home/categories])
+    :navigate-categories! #(>evt [:home/navigate-categories %])
+    :navigate-row! #(>evt [:home/navigate-row %])
+    :open-selected! #(>evt [:home/open-selected])]])

--- a/src/core/gakki/accounts/core.cljs
+++ b/src/core/gakki/accounts/core.cljs
@@ -24,6 +24,10 @@
     [this account album-id]
     "Return a promise...")
 
+  (resolve-artist
+    [this account artist-id]
+    "Return a promise...")
+
   (resolve-playlist
     [this account playlist-id]
     "Return a promise..."))

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -6,6 +6,7 @@
             ["ytmusic" :rename {YTMUSIC YTMusic}]
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]
             [gakki.accounts.core :refer [IAccountProvider]]
+            [gakki.accounts.ytm.consts :refer [ytm-kinds]]
             [gakki.accounts.ytm.album :as album]
             [gakki.accounts.ytm.artist :as artist]
             [gakki.player.ytm :refer [youtube-id->playable]]))
@@ -20,11 +21,6 @@
                (fn [_creds]
                  (p/do!
                    (println "TODO: Persist creds")))})))))
-
-(def ^:private ytm-kinds
-  {"MUSIC_PAGE_TYPE_ALBUM" :album
-   "MUSIC_PAGE_TYPE_ARTIST" :artist
-   "MUSIC_PAGE_TYPE_PLAYLIST" :playlist})
 
 (defn- ->text [obj]
   (or (when (string? obj)

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -171,6 +171,7 @@
                    (:ytm @(re-frame.core/subscribe [:accounts]))
                    "UCvInFYiyeAJOGEjhqJnyaMA") ]
     (prn result)
+    (prn (select-keys result [:title :description :radio :shuffle]))
     )
 
   )

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -58,7 +58,7 @@
    :id (or (j/get-in navigationEndpoint [:watchEndpoint :videoId])
            (j/get-in navigationEndpoint [:browseEndpoint :browseId]))
    :kind (or (when (j/get-in navigationEndpoint [:watchEndpoint :videoId])
-               :song)
+               :track)
 
              (when-let [ytm-kind (j/get-in navigationEndpoint
                                            [:browseEndpoint
@@ -87,7 +87,7 @@
                                                 author album]}]
   {:id id
    :provider :ytm
-   :kind :song  ; an assumption...
+   :kind :track  ; an assumption...
    :duration (->seconds duration)
    :image-url (->thumbnail thumbnail)
    :title (->text title)

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -137,6 +137,9 @@
   (resolve-album [_ account album-id]
     (do-resolve-album account album-id))
 
+  (resolve-artist [_ account artist-id]
+    (do-resolve-artist account artist-id))
+
   (resolve-playlist [_ account playlist-id]
     (do-resolve-playlist account playlist-id))
   )

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -7,6 +7,7 @@
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]
             [gakki.accounts.core :refer [IAccountProvider]]
             [gakki.accounts.ytm.album :as album]
+            [gakki.accounts.ytm.artist :as artist]
             [gakki.player.ytm :refer [youtube-id->playable]]))
 
 (def ^:private account->creds
@@ -118,6 +119,10 @@
   (p/let [^YTMusic ytm (account->client account)]
     (album/load ytm album-id)))
 
+(defn- do-resolve-artist [account artist-id]
+  (p/let [^YTMusic ytm (account->client account)]
+    (artist/load ytm artist-id)))
+
 (deftype YTMAccountProvider []
   IAccountProvider
   (get-name [_this] "YouTube Music")
@@ -163,6 +168,12 @@
   (p/let [result (do-resolve-album
                    (:ytm @(re-frame.core/subscribe [:accounts]))
                    "MPREb_XSoe2FaWnVW") ]
+    (prn result)
+    )
+
+  (p/let [result (do-resolve-artist
+                   (:ytm @(re-frame.core/subscribe [:accounts]))
+                   "UCvInFYiyeAJOGEjhqJnyaMA") ]
     (prn result)
     )
 

--- a/src/core/gakki/accounts/ytm/artist.cljs
+++ b/src/core/gakki/accounts/ytm/artist.cljs
@@ -45,4 +45,4 @@
                       (runs->text))
      :radio (unpack-playlist header :startRadioButton (str "Shuffle " title))
      :shuffle (unpack-playlist header :playButton (str title " Radio"))
-     :items (keep music-shelf->section raw-rows)}))
+     :categories (keep music-shelf->section raw-rows)}))

--- a/src/core/gakki/accounts/ytm/artist.cljs
+++ b/src/core/gakki/accounts/ytm/artist.cljs
@@ -1,0 +1,15 @@
+(ns gakki.accounts.ytm.artist
+  (:require [applied-science.js-interop :as j]
+            [promesa.core :as p]
+            ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]
+            ["ytmusic" :rename {YTMUSIC YTMusic}]))
+
+(defn load [^YTMusic client id]
+  (p/let [response (send-request (.-cookie client)
+                                 #js {:id id
+                                      :type "ARTIST"
+                                      :endpoint "browse"})
+          
+          ]
+    (println "response=" response)
+    ))

--- a/src/core/gakki/accounts/ytm/artist.cljs
+++ b/src/core/gakki/accounts/ytm/artist.cljs
@@ -5,7 +5,8 @@
             ["ytmusic" :rename {YTMUSIC YTMusic}]
             [gakki.accounts.ytm.music-shelf :refer [music-shelf->section]]
             [gakki.accounts.ytm.util :refer [runs->text
-                                             unpack-navigation-endpoint]]))
+                                             unpack-navigation-endpoint]]
+            [gakki.const :as const]))
 
 (defn- unpack-playlist [header button-key title]
   (when-let [radio-id (-> header
@@ -36,6 +37,11 @@
           title (-> header
                     (j/get :title)
                     (runs->text))]
+
+    (when const/debug?
+      #_:clj-kondo/ignore
+      (def last-response response))
+
     {:id id
      :kind :artist
      :provider :ytm

--- a/src/core/gakki/accounts/ytm/artist.cljs
+++ b/src/core/gakki/accounts/ytm/artist.cljs
@@ -2,14 +2,29 @@
   (:require [applied-science.js-interop :as j]
             [promesa.core :as p]
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]
-            ["ytmusic" :rename {YTMUSIC YTMusic}]))
+            ["ytmusic" :rename {YTMUSIC YTMusic}]
+            [gakki.accounts.ytm.music-shelf :refer [music-shelf->section]]
+            [gakki.accounts.ytm.util :refer [runs->text]]))
 
 (defn load [^YTMusic client id]
   (p/let [response (send-request (.-cookie client)
                                  #js {:id id
                                       :type "ARTIST"
                                       :endpoint "browse"})
-          
-          ]
+          raw-rows (-> response
+                       (j/get-in [:contents
+                                  :singleColumnBrowseResultsRenderer
+                                  :tabs
+                                  0
+                                  :tabRenderer
+                                  :content
+                                  :sectionListRenderer
+                                  :contents]))]
     (println "response=" response)
-    ))
+    {:id id
+     :kind :artist
+     :provider :ytm
+     :title (-> response
+                (j/get-in [:header :musicImmersiveHeaderRenderer :title])
+                (runs->text))
+     :items (keep music-shelf->section raw-rows)}))

--- a/src/core/gakki/accounts/ytm/consts.cljs
+++ b/src/core/gakki/accounts/ytm/consts.cljs
@@ -1,0 +1,7 @@
+(ns gakki.accounts.ytm.consts)
+
+(def ytm-kinds
+  {"MUSIC_PAGE_TYPE_ALBUM" :album
+   "MUSIC_PAGE_TYPE_ARTIST" :artist
+   "MUSIC_PAGE_TYPE_PLAYLIST" :playlist
+   "MUSIC_VIDEO_TYPE_ATV" :track})

--- a/src/core/gakki/accounts/ytm/music_shelf.cljs
+++ b/src/core/gakki/accounts/ytm/music_shelf.cljs
@@ -22,13 +22,13 @@
              0
              :url]))
 
-(defn- compose-shelf-item [{:keys [thumbnail items] :as item}]
+(defn- compose-shelf-item [{:keys [image-url items] :as item}]
   ; TODO radio id?
   (if (and (> (count items) 2)
            (= :track (:kind (first items)))
            (= :artist (:kind (second items))))
     (assoc (first items)
-           :thumbnail thumbnail
+           :image-url image-url
            :artist (:title (second items))
            :album (:title (nth items 2)))
 
@@ -46,7 +46,7 @@
   (if-let [flex-columns (j/get-in item [:musicResponsiveListItemRenderer
                                         :flexColumns])]
     (compose-shelf-item
-      {:thumbnail (-> item
+      {:image-url (-> item
                       (j/get-in [:musicResponsiveListItemRenderer :thumbnail])
                       pick-thumbnail)
        :items (keep parse-flex-column-item flex-columns)})
@@ -63,7 +63,7 @@
            :title (runs->text title)
            :subtitle (when-let [subtitle (j/get root :subtitle)]
                        (runs->text subtitle))
-           :thumbnail (-> root
+           :image-url (-> root
                           (j/get :thumbnailRenderer)
                           pick-thumbnail))))
 

--- a/src/core/gakki/accounts/ytm/music_shelf.cljs
+++ b/src/core/gakki/accounts/ytm/music_shelf.cljs
@@ -1,0 +1,105 @@
+(ns gakki.accounts.ytm.music-shelf
+  (:require [applied-science.js-interop :as j]
+            [gakki.accounts.ytm.util :refer [runs->text]]
+            [gakki.accounts.ytm.consts :refer [ytm-kinds]]))
+
+(defn- unpack-navigation-endpoint [^js runs-container]
+  (let [endpoint (j/get-in runs-container [:runs 0 :navigationEndpoint])
+        watch-id (j/get-in endpoint [:watchEndpoint :videoId])]
+    {:id (or watch-id
+             (j/get-in endpoint [:browseEndpoint :browseId]))
+     :provider :ytm
+     :kind (let [raw-kind (j/get-in endpoint [:browseEndpoint
+                                              :browseEndpointContextSupportedConfigs
+                                              :browseEndpointContextMusicConfig
+                                              :pageType])]
+             (get ytm-kinds raw-kind (if watch-id
+                                       :track
+                                       :unknown)))}))
+
+(defn- parse-flex-column-item [^js item]
+  (if-let [root (j/get item :musicResponsiveListItemFlexColumnRenderer)]
+    (let [from-endpoint (unpack-navigation-endpoint (j/get root :text))]
+      (assoc from-endpoint
+             :title (runs->text (j/get root :text))))
+
+    (throw (ex-info "Unexpected flexColumn item"
+                    {:item item}))))
+
+(defn- pick-thumbnail [^js music-thumbnail-renderer-container]
+  (j/get-in music-thumbnail-renderer-container
+            [:musicThumbnailRenderer
+             :thumbnail
+             :thumbnails
+             0
+             :url]))
+
+(defn- compose-shelf-item [{:keys [thumbnail items] :as item}]
+  ; TODO radio id?
+  (if (and (> (count items) 2)
+           (= :track (:kind (first items)))
+           (= :artist (:kind (second items))))
+    (assoc (first items)
+           :thumbnail thumbnail
+           :artist (:title (second items))
+           :album (:title (nth items 2)))
+
+    (assoc item
+           :provider :ytm
+           :kind :unknown)))
+
+
+; ======= Shelf item parsing ==============================
+
+(defmulti parse-shelf-item (fn [^js item] (first (js/Object.keys item))))
+
+(defmethod parse-shelf-item "musicResponsiveListItemRenderer"
+  [^js item]
+  (if-let [flex-columns (j/get-in item [:musicResponsiveListItemRenderer
+                                        :flexColumns])]
+    (compose-shelf-item
+      {:thumbnail (-> item
+                      (j/get-in [:musicResponsiveListItemRenderer :thumbnail])
+                      pick-thumbnail)
+       :items (keep parse-flex-column-item flex-columns)})
+
+    (throw (ex-info "Unexpected musicResponsiveListItemRenderer contents"
+                    {:contents item}))))
+
+(defmethod parse-shelf-item "musicTwoRowItemRenderer"
+  [^js item]
+  (let [root (j/get item :musicTwoRowItemRenderer)
+        title (j/get root :title)
+        endpoint (unpack-navigation-endpoint title)]
+    (assoc endpoint
+           :title (runs->text title)
+           :subtitle (when-let [subtitle (j/get root :subtitle)]
+                       (runs->text subtitle))
+           :thumbnail (-> root
+                          (j/get :thumbnailRenderer)
+                          pick-thumbnail))))
+
+
+; ======= Shelf parsing ===================================
+
+(defmulti music-shelf->section (fn [container] (first (js/Object.keys container))))
+
+(defmethod music-shelf->section "musicShelfRenderer"
+  [^js container]
+  (j/let [^:js {renderer :musicShelfRenderer} container
+          ^:js {:keys [title contents]} renderer]
+    {:title (runs->text title)
+     :items (keep parse-shelf-item contents)}))
+
+(defmethod music-shelf->section "musicCarouselShelfRenderer"
+  [^js container]
+  (j/let [^:js {renderer :musicCarouselShelfRenderer} container
+          ^:js {:keys [header contents]} renderer]
+    {:title (runs->text (j/get-in header [:musicCarouselShelfBasicHeaderRenderer
+                                          :title]))
+     :items (keep parse-shelf-item contents)}))
+
+(defmethod music-shelf->section :default
+  [^js section]
+  (println "Unexpected music shelf section: " section)
+  nil)

--- a/src/core/gakki/accounts/ytm/music_shelf.cljs
+++ b/src/core/gakki/accounts/ytm/music_shelf.cljs
@@ -1,21 +1,7 @@
 (ns gakki.accounts.ytm.music-shelf
   (:require [applied-science.js-interop :as j]
-            [gakki.accounts.ytm.util :refer [runs->text]]
-            [gakki.accounts.ytm.consts :refer [ytm-kinds]]))
-
-(defn- unpack-navigation-endpoint [^js runs-container]
-  (let [endpoint (j/get-in runs-container [:runs 0 :navigationEndpoint])
-        watch-id (j/get-in endpoint [:watchEndpoint :videoId])]
-    {:id (or watch-id
-             (j/get-in endpoint [:browseEndpoint :browseId]))
-     :provider :ytm
-     :kind (let [raw-kind (j/get-in endpoint [:browseEndpoint
-                                              :browseEndpointContextSupportedConfigs
-                                              :browseEndpointContextMusicConfig
-                                              :pageType])]
-             (get ytm-kinds raw-kind (if watch-id
-                                       :track
-                                       :unknown)))}))
+            [gakki.accounts.ytm.util :refer [runs->text
+                                             unpack-navigation-endpoint]]))
 
 (defn- parse-flex-column-item [^js item]
   (if-let [root (j/get item :musicResponsiveListItemFlexColumnRenderer)]
@@ -98,6 +84,10 @@
     {:title (runs->text (j/get-in header [:musicCarouselShelfBasicHeaderRenderer
                                           :title]))
      :items (keep parse-shelf-item contents)}))
+
+(defmethod music-shelf->section "musicDescriptionShelfRenderer" [_]
+  ; Probably can skip quietly
+  nil)
 
 (defmethod music-shelf->section :default
   [^js section]

--- a/src/core/gakki/accounts/ytm/util.cljs
+++ b/src/core/gakki/accounts/ytm/util.cljs
@@ -1,0 +1,10 @@
+(ns gakki.accounts.ytm.util
+  (:require [applied-science.js-interop :as j]
+            [clojure.string :as str]))
+
+(defn runs->text [^js runs-container]
+  (when-let [runs (j/get runs-container :runs)]
+    (->> runs
+         (map #(j/get % :text))
+         (str/join " "))))
+

--- a/src/core/gakki/accounts/ytm/util.cljs
+++ b/src/core/gakki/accounts/ytm/util.cljs
@@ -1,10 +1,29 @@
 (ns gakki.accounts.ytm.util
   (:require [applied-science.js-interop :as j]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [gakki.accounts.ytm.consts :refer [ytm-kinds]]))
 
 (defn runs->text [^js runs-container]
   (when-let [runs (j/get runs-container :runs)]
     (->> runs
          (map #(j/get % :text))
          (str/join " "))))
+
+(defn unpack-navigation-endpoint [^js runs-container-or-endpoint]
+  (let [endpoint (or (j/get runs-container-or-endpoint :navigationEndpoint)
+                     (j/get-in runs-container-or-endpoint [:runs 0 :navigationEndpoint]))
+        playlist-id (j/get-in endpoint [:watchPlaylistEndpoint :playlistId])
+        watch-id (or (j/get-in endpoint [:watchEndpoint :videoId])
+                     playlist-id)]
+    {:id (or watch-id
+             (j/get-in endpoint [:browseEndpoint :browseId]))
+     :provider :ytm
+     :kind (let [raw-kind (j/get-in endpoint [:browseEndpoint
+                                              :browseEndpointContextSupportedConfigs
+                                              :browseEndpointContextMusicConfig
+                                              :pageType])]
+             (get ytm-kinds raw-kind (cond
+                                       playlist-id :playlist
+                                       watch-id :track
+                                       :else :unknown)))}))
 

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -22,6 +22,13 @@
   (fn [db [new-page]]
     (assoc db :page new-page)))
 
+(reg-event-db
+  :navigate/back!
+  [trim-v]
+  (fn [db _]
+    ; TODO backstack
+    (assoc db :page [:home])))
+
 
 ; ======= Auth/Providers ==================================
 
@@ -136,6 +143,11 @@
 
                  ; Unresolved album; fetch and resolve now:
                  {:providers/resolve-and-open [:album (:accounts db) item]})
+
+        :artist (if (:categories item)
+                  {:dispatch [:navigate! [:artist (:id item)]]}
+
+                  {:providers/resolve-and-open [:artist (:accounts db) item]})
 
         (println "TODO support opening: " item)))))
 

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -157,7 +157,7 @@
   (fn [{:keys [db]} [item]]
     (let [item (inflate-item db item)]
       (case (:kind item)
-        :song {:dispatch [::set-current-playable item]}
+        :track {:dispatch [::set-current-playable item]}
 
         :playlist (if-let [items (seq (:items item))]
                     {:dispatch [:player/play-items items]}

--- a/src/core/gakki/fx.cljs
+++ b/src/core/gakki/fx.cljs
@@ -46,11 +46,13 @@
       (if (and provider account)
         (-> (p/let [f (case kind
                         :album ap/resolve-album
+                        :artist ap/resolve-artist
                         :playlist ap/resolve-playlist)
                     result (f provider
                               account
                               (:id entity))]
-              (if (seq (:items result))
+              (if (or (seq (:items result))
+                      (seq (:categories result)))
                 (>evt [:player/on-resolved kind result :action/open])
                 (println "[err: " k "] Empty " kind result)))
 

--- a/src/core/gakki/subs.cljs
+++ b/src/core/gakki/subs.cljs
@@ -5,6 +5,8 @@
 
 (reg-sub :page :page)
 (reg-sub :accounts :accounts)
+(reg-sub :artists :artist)
+(reg-sub ::carousel-data ::carousel-data)
 
 (reg-sub
   :loading?
@@ -62,10 +64,32 @@
   (fn [db _]
     (:home/selection db)))
 
+
+; ======= Persistent page-based Carousels =================
+
 (reg-sub
-  :home/selection
+  ::carousel-categories
+  :<- [:page]
   :<- [::home-categories]
-  :<- [::home-selection]
+  :<- [:artists]
+  (fn [[page home-categories artists] _]
+    (case (first page)
+      :home home-categories
+      :artist (get-in artists [(second page) :categories])
+
+      nil)))
+
+(reg-sub
+  ::carousel-selection
+  :<- [:page]
+  :<- [::carousel-data]
+  (fn [[page carousel-data]]
+    (:selection (get-in carousel-data page))))
+
+(reg-sub
+  :carousel/selection
+  :<- [::carousel-categories]
+  :<- [::carousel-selection]
   (fn [[categories selections] _]
     (or (when (and (:category selections)
                    (:item selections))
@@ -81,9 +105,9 @@
                    (:id item))}))))
 
 (reg-sub
-  :home/categories
-  :<- [::home-categories]
-  :<- [:home/selection]
+  :carousel/categories
+  :<- [::carousel-categories]
+  :<- [:carousel/selection]
   (fn [[categories {selected-cat :category selected-item :item}] _]
     (->> categories
          (map (fn [category]
@@ -111,5 +135,6 @@
 
 (reg-sub
   :artist
-  (fn [db [_ id]]
-    (get-in db [:artist id])))
+  :<- [:artists]
+  (fn [artists [_ id]]
+    (get artists id)))

--- a/src/core/gakki/subs.cljs
+++ b/src/core/gakki/subs.cljs
@@ -108,3 +108,8 @@
   :album
   (fn [db [_ id]]
     (get-in db [:album id])))
+
+(reg-sub
+  :artist
+  (fn [db [_ id]]
+    (get-in db [:artist id])))


### PR DESCRIPTION
<img width="682" alt="Screen Shot 2021-05-29 at 9 58 56 AM" src="https://user-images.githubusercontent.com/816150/120072999-7c52dd00-c064-11eb-9e46-2121c9b6d978.png">

- Scaffold out loading artist pages
- Finish support for parsing all (current) artist rows
- Support unpacking radio/shuffle playlists for artist
- Wire up initial artist page
- Omit the Videos section of Artist pages
- Refactor carousel logic to be shared, persistent
- Refactor: `:kind :song` -> `:kind :track`
