### PR TITLE
Support playing uploaded files (non opus/vorbis-formatted files)

### DIFF
--- a/src/core/gakki/accounts/ytm/album.cljs
+++ b/src/core/gakki/accounts/ytm/album.cljs
@@ -1,4 +1,5 @@
 (ns gakki.accounts.ytm.album
+  (:refer-clojure :exclude [load])
   (:require [applied-science.js-interop :as j]
             [promesa.core :as p]
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]

--- a/src/core/gakki/accounts/ytm/artist.cljs
+++ b/src/core/gakki/accounts/ytm/artist.cljs
@@ -1,4 +1,5 @@
 (ns gakki.accounts.ytm.artist
+  (:refer-clojure :exclude [load])
   (:require [applied-science.js-interop :as j]
             [promesa.core :as p]
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]

--- a/src/core/gakki/accounts/ytm/playback.cljs
+++ b/src/core/gakki/accounts/ytm/playback.cljs
@@ -26,6 +26,7 @@
       {:config {:container container
                 :codec codec
 
+                :frame-size 960
                 :duration (->int (j/get json :approxDurationMs))
                 :loudness-db (->float (j/get json :loudnessDb))
                 :average-bitrate (->int (j/get json :averageBitrate))

--- a/src/core/gakki/accounts/ytm/playback.cljs
+++ b/src/core/gakki/accounts/ytm/playback.cljs
@@ -1,0 +1,102 @@
+(ns gakki.accounts.ytm.playback
+  (:refer-clojure :exclude [load])
+  (:require [applied-science.js-interop :as j]
+            [promesa.core :as p]
+            ["ytdl-core" :as ytdl]
+            ["ytmusic/dist/lib/utils" :rename {sendRequest send-request
+                                               generateBody generate-body}]
+            ["ytmusic" :rename {YTMUSIC YTMusic}]
+            [gakki.util.convert :refer [->float ->int]]))
+
+
+; ======= Talking to YTM directly =========================
+
+(def ^:private re-mime-type #"audio/([^;]+); codecs=\"([a-z0-9]+)")
+
+(defn- unpack-url [_parts]
+  ; TODO: :signatureCipher is a querystring that contains :url and some other
+  ; things. We *may* be able to extra a usable download URL from it if we can
+  ; figure out what YTM is doing, and then remove the ytdl-core dependency
+  nil)
+
+(defn parse-audio-format [json]
+  (when-let [[_ container codec] (re-find re-mime-type (j/get json :mimeType))]
+    (when-let [url (or (j/get json :url)
+                       (unpack-url (j/get json :signatureCipher)))]
+      {:config {:container container
+                :codec codec
+
+                :duration (->int (j/get json :approxDurationMs))
+                :loudness-db (->float (j/get json :loudnessDb))
+                :average-bitrate (->int (j/get json :averageBitrate))
+                :sample-rate (->int (j/get json :audioSampleRate))
+                :channels (->int (j/get json :audioChannels))}
+       :url url})))
+
+(defn- load-ytm [cookies id]
+  (p/let [body (-> (generate-body #js {})
+                   (j/assoc! :videoId id))
+          response (send-request cookies
+                                 (j/lit
+                                   {:endpoint "player"
+                                    :body body}))
+          formats (j/get-in response [:streamingData :adaptiveFormats])]
+    (->> formats
+         (keep parse-audio-format)
+         (sort-by (comp :average-bitrate :config) >)
+         first)))
+
+
+; ======= ytdl-core =======================================
+
+(defn- load-ytdl-core
+  "This fn uses ytdl-core to load the audio format as if it were a youtube
+   video, which is convenient and effective for YTM-provided tracks.
+   We may be able to get rid of this dependency in the future..."
+  [cookies id]
+  (p/let [options (j/lit {:requestOptions
+                          {:headers {:cookie cookies}}})
+          info (ytdl/getInfo id options)
+          fmt (ytdl/chooseFormat
+                (j/get info :formats)
+                #js {:quality "highestaudio"})
+
+          config {:container (j/get fmt :container)
+                  :codec (j/get fmt :audioCodec)
+
+                  ; NOTE: You'd think these would be integers, but...
+                  ; they might not be.
+                  :duration (->int (j/get fmt :approxDurationMs))
+                  :loudness-db (->int (j/get fmt :loudnessDb))
+                  :sample-rate (->int (j/get fmt :audioSampleRate))
+                  :channels (->int (j/get fmt :audioChannels))}]
+
+    {:config config
+     :url (j/get fmt :url)}))
+
+; ======= Public interface ================================
+
+(defn load [^YTMusic client, id]
+  (let [cookies (when client
+                  (.-cookie client))]
+    ; NOTE: Currently we request from both ytdl-core and ytm directly
+    ; *in parallel* for expediency. This is because we haven't yet figured
+    ; out how to extract an URL from YTM responses that don't explicitly
+    ; include an URL (which we only seem to get from uploaded tracks).
+    (p/plet [from-ytm (load-ytm cookies id)
+             from-ytdl (-> (load-ytdl-core cookies id)
+                           (p/catch (constantly nil)))]
+      (or from-ytm
+          from-ytdl))))
+
+#_:clj-kondo/ignore
+(comment
+
+  (-> (p/let [client (gakki.accounts.ytm.creds/account->client
+                       @(re-frame.core/subscribe [:account :ytm]))
+              result (load client "-r-Pq3PnWSs")]
+        (cljs.pprint/pprint result))
+      (p/catch #(do (cljs.pprint/pprint (ex-data %))
+                    (println (.-stack %)))))
+
+  )

--- a/src/core/gakki/accounts/ytm/playback.cljs
+++ b/src/core/gakki/accounts/ytm/playback.cljs
@@ -6,6 +6,7 @@
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request
                                                generateBody generate-body}]
             ["ytmusic" :rename {YTMUSIC YTMusic}]
+            [gakki.const :as const]
             [gakki.util.convert :refer [->float ->int]]))
 
 
@@ -26,7 +27,7 @@
       {:config {:container container
                 :codec codec
 
-                :frame-size 960
+                :frame-size const/default-frame-size
                 :duration (->int (j/get json :approxDurationMs))
                 :loudness-db (->float (j/get json :loudnessDb))
                 :average-bitrate (->int (j/get json :averageBitrate))

--- a/src/core/gakki/accounts/ytm/playlist.cljs
+++ b/src/core/gakki/accounts/ytm/playlist.cljs
@@ -1,4 +1,5 @@
 (ns gakki.accounts.ytm.playlist
+  (:refer-clojure :exclude [load])
   (:require [applied-science.js-interop :as j]
             [clojure.string :as str]
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request}]

--- a/src/core/gakki/accounts/ytm/search_suggest.cljs
+++ b/src/core/gakki/accounts/ytm/search_suggest.cljs
@@ -1,4 +1,5 @@
 (ns gakki.accounts.ytm.search-suggest
+  (:refer-clojure :exclude [load])
   (:require [applied-science.js-interop :as j]
             [promesa.core :as p]
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request
@@ -40,5 +41,5 @@
         (cljs.pprint/pprint result))
       (p/catch #(do (cljs.pprint/pprint (ex-data %))
                     (println (.-stack %)))))
-  
+
   )

--- a/src/core/gakki/const.cljs
+++ b/src/core/gakki/const.cljs
@@ -5,5 +5,12 @@
 (def max-volume-int 10)
 (def suppressed-volume-percent 0.20)
 
+; TODO Not sure how this should be determined; maybe it's just a buffer size and
+; doesn't really matter what value it is...
+(def default-frame-size 960)
+
+; NOTE: We currently *always* decode to 16bit signed PCM data, so 2 bytes per sample
+(def bytes-per-sample 2)
+
 (goog-define discord-app-id "")
 (goog-define discord-oauth-secret "")

--- a/src/core/gakki/player/analyze.cljs
+++ b/src/core/gakki/player/analyze.cljs
@@ -3,6 +3,7 @@
             [clojure.string :as str]
             ["ffmpeg-static" :as ffmpeg-path]
             [promesa.core :as p]
+            [gakki.const :as const]
             [gakki.util.convert :refer [->int]]))
 
 (def duration-regex #"Duration: (\d+):(\d+):(\d+).(\d+)")
@@ -42,10 +43,7 @@
        :codec codec
        :container (parse-container output)
 
-       ; TODO extract this:
-       :frame-size 960}
-
-      )))
+       :frame-size const/default-frame-size})))
 
 (defn analyze-audio [path]
   (p/create

--- a/src/core/gakki/player/clip.cljs
+++ b/src/core/gakki/player/clip.cljs
@@ -1,6 +1,7 @@
 (ns gakki.player.clip
   (:require [applied-science.js-interop :as j]
             ["audify" :refer [RtAudio RtAudioFormat]]
+            [gakki.const :as const]
             ["stream" :refer [Readable Writable]]
             [gakki.util.logging :as log]))
 
@@ -75,7 +76,7 @@
                      nil ; No input stream
                      (.-RTAUDIO_SINT16 RtAudioFormat)
                      sample-rate
-                     (or frame-size 960)
+                     (or frame-size const/default-frame-size)
                      "gakki" ; stream name
                      nil ; input callback
                      nil ; output callback

--- a/src/core/gakki/player/decode.cljs
+++ b/src/core/gakki/player/decode.cljs
@@ -1,5 +1,6 @@
 (ns gakki.player.decode
   (:require [applied-science.js-interop :as j]
+            [gakki.const :as const]
             ["prism-media" :as prism]
             [gakki.player.stream.chunking :as chunking]
             [gakki.util.logging :as log]))
@@ -29,7 +30,7 @@
                   "opus" (prism/opus.Decoder.
                            #js {:rate (:sample-rate config)
                                 :channels (:channels config)
-                                :frameSize 960})
+                                :frameSize const/default-frame-size})
 
                   (do
                     (log/debug "No optimized decoder for " codec
@@ -50,9 +51,9 @@
 
     ; Ensure that the decoded data is chunked appropriately to match the
     ; configured :frame-size (important to make RtAudio/Audify happy)
-    (if (:frame-size config)
+    (if-let [frame-size (:frame-size config)]
       (-> decoded
           (chunking/nbytes (* (:channels config)
-                              2 ; 2 bytes for signed 16-bit format
-                              (:frame-size config))))
+                              const/bytes-per-sample
+                              frame-size)))
       decoded)))

--- a/src/core/gakki/player/decode.cljs
+++ b/src/core/gakki/player/decode.cljs
@@ -1,5 +1,8 @@
 (ns gakki.player.decode
-  (:require ["prism-media" :as prism]))
+  (:require [applied-science.js-interop :as j]
+            ["prism-media" :as prism]
+            [gakki.player.stream.chunking :as chunking]
+            [gakki.util.logging :as log]))
 
 (defn decode-stream
   "Given a config map and an encoded audio stream, return a stream that decodes
@@ -11,22 +14,45 @@
     :container \"webm\"  ; eg
     :codec \"opus\"}     ; eg
    "
-  [config ^js stream]
-  (let [demuxer (case (:container config)
+  [{:keys [container codec] :as config} ^js stream]
+  (js/console.error "config = " (str config))
+  (let [demuxer (case container
                   "ogg" (prism/opus.OggDemuxer.)
-                  "webm" (case (:codec config)
+                  "webm" (case codec
                            "opus" (prism/opus.WebmDemuxer.)
                            "vorbis" (prism/vorbis.WebmDemuxer.))
-                  nil nil)
 
-        ; TODO we ought to be able to fall back to prism.Ffmpeg
-        decoder (case (:codec config)
+                  ; Assume no specific demuxer necessary:
+                  nil)
+
+        decoder (case codec
                   "opus" (prism/opus.Decoder.
                            #js {:rate (:sample-rate config)
                                 :channels (:channels config)
-                                :frameSize 960}))
+                                :frameSize 960})
+
+                  (do
+                    (log/debug "No optimized decoder for " codec
+                               "; falling back to ffmpeg")
+                    (-> (prism/FFmpeg.
+                          (j/lit
+                            {:args [:-loglevel "0"
+                                    :-ac (:channels config)
+                                    :-i "-"
+                                    :-f "s16le"
+                                    :-acodec "pcm_s16le"
+                                    :-ac (:channels config)]})))))
 
         demuxed (if demuxer
                   (.pipe stream demuxer)
-                  stream)]
-    (.pipe demuxed decoder)))
+                  stream)
+        decoded (.pipe demuxed decoder)]
+
+    ; Ensure that the decoded data is chunked appropriately to match the
+    ; configured :frame-size (important to make RtAudio/Audify happy)
+    (if (:frame-size config)
+      (-> decoded
+          (chunking/nbytes (* (:channels config)
+                              2 ; 2 bytes for signed 16-bit format
+                              (:frame-size config))))
+      decoded)))

--- a/src/core/gakki/player/decode.cljs
+++ b/src/core/gakki/player/decode.cljs
@@ -16,7 +16,6 @@
     :codec \"opus\"}     ; eg
    "
   [{:keys [container codec] :as config} ^js stream]
-  (js/console.error "config = " (str config))
   (let [demuxer (case container
                   "ogg" (prism/opus.OggDemuxer.)
                   "webm" (case codec

--- a/src/core/gakki/player/stream/chunking.cljs
+++ b/src/core/gakki/player/stream/chunking.cljs
@@ -1,0 +1,48 @@
+(ns gakki.player.stream.chunking
+  (:require ["stream" :refer [Transform Readable]]))
+
+(defn create-nbytes-chunking-transform-old [n]
+  (Transform.
+    #js {:transform
+         (fn transform [chnk _encoding callback]
+           (cond
+             (= (.-length chnk) n)
+             (do (this-as this (.push this chnk))
+                 (callback))
+
+             ; An even number of chnks combined
+             (= 0 (mod (.-length chnk) n))
+             (loop [i 0]
+               (if (< i (.-length chnk))
+                 (do (this-as this (.push this (.slice chnk i (+ i n))))
+                     (recur (+ i n)))
+                 (callback)))
+
+             :else
+             (throw (ex-info
+                      (str "Unexpected chunk size: " (.-length chnk))
+                      {:chunk-length (.-length chnk)
+                       :n n}))))}))
+
+(defn- create-nbytes-chunking-transform [n]
+  (let [storage (atom (js/Buffer.alloc 0))]
+    (Transform.
+      #js {:transform
+           (fn transform [chnk _encoding callback]
+             (let [b (swap! storage #(js/Buffer.concat #js [% chnk]))]
+               (loop [start 0
+                      end n]
+                 (if (< end (.-length chnk))
+                   (do (this-as this (.push this (.slice b start end)))
+                       (recur (+ start n)
+                              (+ end n)))
+
+                   (do
+                     (reset! storage (.slice b start))
+                     (callback))))))})))
+
+(defn ^Readable nbytes
+  "Pipes the Readable input stream into and returns a Transform stream
+   which chunks its input into Buffers of size divisible by `n`."
+  [^Readable input, n]
+  (.pipe input (create-nbytes-chunking-transform n)))

--- a/src/core/gakki/player/stream/chunking.cljs
+++ b/src/core/gakki/player/stream/chunking.cljs
@@ -1,29 +1,6 @@
 (ns gakki.player.stream.chunking
   (:require ["stream" :refer [Transform Readable]]))
 
-(defn create-nbytes-chunking-transform-old [n]
-  (Transform.
-    #js {:transform
-         (fn transform [chnk _encoding callback]
-           (cond
-             (= (.-length chnk) n)
-             (do (this-as this (.push this chnk))
-                 (callback))
-
-             ; An even number of chnks combined
-             (= 0 (mod (.-length chnk) n))
-             (loop [i 0]
-               (if (< i (.-length chnk))
-                 (do (this-as this (.push this (.slice chnk i (+ i n))))
-                     (recur (+ i n)))
-                 (callback)))
-
-             :else
-             (throw (ex-info
-                      (str "Unexpected chunk size: " (.-length chnk))
-                      {:chunk-length (.-length chnk)
-                       :n n}))))}))
-
 (defn- create-nbytes-chunking-transform [n]
   (let [storage (atom (js/Buffer.alloc 0))]
     (Transform.

--- a/src/core/gakki/player/ytm.cljs
+++ b/src/core/gakki/player/ytm.cljs
@@ -1,39 +1,17 @@
 (ns gakki.player.ytm
   (:require [applied-science.js-interop :as j]
             ["node-fetch" :as fetch]
-            ["ytdl-core" :as ytdl]
             [promesa.core :as p]
-            [gakki.accounts.ytm.creds :refer [account->cookies]]
-            [gakki.util.convert :refer [->int]]
+            [gakki.accounts.ytm.creds :refer [account->client]]
+            [gakki.accounts.ytm.playback :as playback]
             [gakki.player.core :as gp]
             [gakki.player.pcm :as pcm]
             [gakki.player.track :as track]))
 
-(defn- youtube-id->url [account id]
-  (p/let [cookies (when account
-                    (account->cookies account))
-          options (j/lit {:requestOptions
-                          {:headers {:cookie cookies}}})
-          info (ytdl/getInfo id options)
-          fmt (ytdl/chooseFormat
-                (j/get info :formats)
-                #js {:quality "highestaudio"})
-
-          config {:container (j/get fmt :container)
-                  :codec (j/get fmt :audioCodec)
-
-                  ; NOTE: You'd think these would be integers, but...
-                  ; they might not be.
-                  :duration (->int (j/get fmt :approxDurationMs))
-                  :loudness-db (->int (j/get fmt :loudnessDb))
-                  :sample-rate (->int (j/get fmt :audioSampleRate))
-                  :channels (->int (j/get fmt :audioChannels))}]
-
-    {:config config
-     :url (j/get fmt :url)}))
-
 (defn youtube-id->stream [account id]
-  (p/let [{:keys [config url]} (youtube-id->url account id)
+  (p/let [client (when account
+                   (account->client account))
+          {:keys [config url]} (playback/load client id)
           response (fetch url)
           ^js stream (j/get response :body)]
     {:config config

--- a/src/core/gakki/util/convert.cljs
+++ b/src/core/gakki/util/convert.cljs
@@ -1,4 +1,7 @@
 (ns gakki.util.convert)
 
+(defn ->float [v]
+  (js/parseFloat v 10))
+
 (defn ->int [v]
   (js/parseInt v 10))


### PR DESCRIPTION
Fixes #17 

- Attempt to support playback of uploaded tracks via YTM's API
- Use ffmpeg to decode "other" file types
- Refactor 960 as the default "frame size" into a const

Still TODO:

- ~Hopefully, simplify the process of fetching the data for these files and avoid needing to make two requests in parallel~ It turns out this very difficult; ytdl-core does quite a bit here to make it work.