### PR TITLE
Clean up and unify logging

### DIFF
--- a/src/cli/gakki/cli/input.cljs
+++ b/src/cli/gakki/cli/input.cljs
@@ -1,5 +1,6 @@
 (ns gakki.cli.input
-  (:require ["ink" :as k]
+  (:require [gakki.util.logging :as log]
+            ["ink" :as k]
             ["react" :rename {useEffect use-effect}]
             [reagent.impl.component :as reagent-impl]
             [gakki.cli.keys :refer [->key]]
@@ -77,9 +78,9 @@
               (f)
 
               :else
-              (println "ERROR: Handler to " the-key " was not a zero-arity fn."
-                       "\n  Value: " f
-                       "\n  Registered: " owner)))))))
+              (log/error "Handler to " the-key " was not a zero-arity fn."
+                         "\n  Value: " f
+                         "\n  Registered: " owner)))))))
 
   ; This is a functional component that doesn't render anything
   nil)

--- a/src/cli/gakki/views/auth/ytm.cljs
+++ b/src/cli/gakki/views/auth/ytm.cljs
@@ -1,6 +1,7 @@
 (ns gakki.views.auth.ytm
   (:require [archetype.util :refer [<sub >evt]]
             [applied-science.js-interop :as j]
+            [gakki.util.logging :as log]
             ["node-fetch" :default fetch]
             ["ink" :as k]
             ["ink-spinner" :default Spinner]
@@ -38,7 +39,7 @@
         (>evt [:auth/save :ytm account]))
 
       (p/catch (fn [e]
-                 (println e)
+                 (log/error "Failed to login to YTM:" e)
                  (reset! state :error)))))
 
 (defn- logged-out []

--- a/src/core/gakki/accounts/ytm/album.cljs
+++ b/src/core/gakki/accounts/ytm/album.cljs
@@ -72,7 +72,6 @@
 
 (defn- inflate-like-playlist [id response]
   (let [like-playlist (playlist/inflate id :album response)]
-    (println "LIKE PL: " like-playlist)
     (when (seq (:items like-playlist))
       like-playlist)))
 

--- a/src/core/gakki/accounts/ytm/music_shelf.cljs
+++ b/src/core/gakki/accounts/ytm/music_shelf.cljs
@@ -3,7 +3,8 @@
             [clojure.string :as str]
             [gakki.accounts.ytm.util :as util :refer [->seconds
                                                       runs->text
-                                                      unpack-navigation-endpoint]]))
+                                                      unpack-navigation-endpoint]]
+            [gakki.util.logging :as log]))
 
 (def ^:private ignored-section-titles #{"Videos"})
 
@@ -140,5 +141,5 @@
 
 (defmethod music-shelf->section :default
   [^js section]
-  (println "Unexpected music shelf section: " section)
+  (log/error "Unexpected music shelf section: " section)
   nil)

--- a/src/core/gakki/accounts/ytm/playback.cljs
+++ b/src/core/gakki/accounts/ytm/playback.cljs
@@ -93,7 +93,6 @@
                        @(re-frame.core/subscribe [:account :ytm]))
               result (load client "-r-Pq3PnWSs")]
         (cljs.pprint/pprint result))
-      (p/catch #(do (cljs.pprint/pprint (ex-data %))
-                    (println (.-stack %)))))
+      (p/catch log/error))
 
   )

--- a/src/core/gakki/accounts/ytm/search.cljs
+++ b/src/core/gakki/accounts/ytm/search.cljs
@@ -47,7 +47,6 @@
                        @(re-frame.core/subscribe [:account :ytm]))
               result (perform client "last of us")]
         (cljs.pprint/pprint result))
-      (p/catch #(do (cljs.pprint/pprint (ex-data %))
-                    (println (.-stack %)))))
-  
+      (p/catch log/error))
+
   )

--- a/src/core/gakki/accounts/ytm/search_suggest.cljs
+++ b/src/core/gakki/accounts/ytm/search_suggest.cljs
@@ -39,7 +39,6 @@
                        @(re-frame.core/subscribe [:account :ytm]))
               result (load client "last")]
         (cljs.pprint/pprint result))
-      (p/catch #(do (cljs.pprint/pprint (ex-data %))
-                    (println (.-stack %)))))
+      (p/catch log/error))
 
   )

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -229,7 +229,7 @@
 
                   {:providers/resolve-and-open [:artist (:accounts db) item]})
 
-        (println "TODO support opening: " item)))))
+        (log/error "TODO support opening: " item)))))
 
 (defn- clean-entity [entity]
   (if (and (seq (:items entity))
@@ -384,7 +384,7 @@
                          :account (get accounts (:provider next-item))}})))
 
 (defmethod handle-player-event :default [_ {what :type}]
-  (println "WARN: Unexpected player event type: " what))
+  (log/error "Unexpected player event type: " what))
 
 (reg-event-fx
   :player/event

--- a/src/core/gakki/fx.cljs
+++ b/src/core/gakki/fx.cljs
@@ -111,8 +111,7 @@
                           (when results
                             (>evt [:home/replace k results])))
                         (p/catch (fn [e]
-                                   ; TODO logging
-                                   (println "[err: " k "] " e)))))))
+                                   (log/error "Loading home from " k ":" e)))))))
            p/all
            (p/map (fn []
                     (>evt [:loading/update-count dec])))))))
@@ -139,17 +138,15 @@
               (if (or (seq (:items result))
                       (seq (:categories result)))
                 (>evt [:player/on-resolved kind result :action/open])
-                (println "[err: " k "] Empty " kind result)))
+                (log/error "Empty " kind " from " k " = " result)))
 
             (p/catch (fn [e]
-                       ; TODO logging...
-                       (println "[err: " k "] " e)))
+                       (log/error "Resolving " kind " from " e ": " e)))
 
             (p/finally (fn []
-                         (>evt [:loading/update-count dec])))
-            )
+                         (>evt [:loading/update-count dec]))))
 
-        (println "[err: " k "] Invalid provider or no account")))))
+        (log/error "Invalid provider or no account: " k)))))
 
 (reg-fx
   :providers/search
@@ -159,8 +156,7 @@
     (-> (p/let [results (accounts/search accounts query)]
           (>evt [:search/on-loaded query results]))
         (p/catch (fn [e]
-                   ; TODO logging...
-                   (println "[err] " e)
+                   (log/error "Performing search:" e)
                    (>evt [:search/on-loaded query e]))))))
 
 ; ======= Player ==========================================

--- a/src/core/gakki/integrations/discord.cljs
+++ b/src/core/gakki/integrations/discord.cljs
@@ -90,11 +90,10 @@
                     (retry-connect (inc retry-count))
 
                     :else
-                    (do (println "Error connecting to Discord"
-                                 "\ncode:" code
-                                 "\nretry-count: " retry-count
-                                 "\n" e)
-                        (js/console.log e))))))))
+                    (log/error "Connecting to Discord"
+                               "\ncode:" code
+                               "\nretry-count: " retry-count
+                               e)))))))
 
 (defn- retry-connect [retry-count]
   (when (> retry-count 0)

--- a/src/core/gakki/player/pcm/caching.cljs
+++ b/src/core/gakki/player/pcm/caching.cljs
@@ -195,7 +195,7 @@
   (-> (fs/rename tmp-path destination-path)
       (p/catch
         (fn [err]
-          (println "Error completing download:" err)))))
+          (log/error "Unable to 'complete' download:" err)))))
 
 (defn create [^Readable stream, config destination-path]
   (let [tmp-path (str destination-path ".progress")

--- a/src/core/gakki/util/logging.cljs
+++ b/src/core/gakki/util/logging.cljs
@@ -39,6 +39,24 @@
 (def player (of :player))
 
 
+; ======= Error logging ===================================
+
+(defn error? [e]
+  (instance? js/Error e))
+
+(defn error [& message]
+  (let [ex (some #(when (error? %) %) message)
+        without-ex (remove error? message)]
+    ; NOTE: Error logs cannot be disabled
+    (apply println ((chalk/inverse.hsv 0 40 100)
+                    (str " ERROR "))
+           (if-some [m (ex-message ex)]
+             (concat without-ex [m])
+             without-ex))
+    (when-let [stack (when ex (.-stack ex))]
+      (println (chalk/gray stack)))))
+
+
 ; ======= Timing ==========================================
 
 (def ^:private colorize-timing (colorizer ":timing"))

--- a/src/core/gakki/util/logging.cljs
+++ b/src/core/gakki/util/logging.cljs
@@ -1,6 +1,7 @@
 (ns gakki.util.logging
   (:require ["chalk" :as chalk]
             [clojure.string :as str]
+            [cljs.pprint :refer [pprint]]
             [promesa.core :as p]
             [re-frame.core :as re-frame]
             [gakki.const :as const]))
@@ -45,14 +46,31 @@
   (instance? js/Error e))
 
 (defn error [& message]
-  (let [ex (some #(when (error? %) %) message)
-        without-ex (remove error? message)]
+  (let [tag (if (keyword? (first message))
+              (first message)
+              nil)
+        message (if tag
+                  (next message)
+                  message)
+        ex (some #(when (error? %) %) message)
+        without-ex (remove error? message)
+
+        last-map (when (map? (last without-ex))
+                   (last without-ex))
+        without-ex (if (some? last-map)
+                  (butlast without-ex)
+                  without-ex)]
+
     ; NOTE: Error logs cannot be disabled
     (apply println ((chalk/inverse.hsv 0 40 100)
-                    (str " ERROR "))
+                    (str " ERROR" tag " "))
            (if-some [m (ex-message ex)]
              (concat without-ex [m])
              without-ex))
+    (when (some? last-map)
+      (pprint last-map))
+    (when-let [data (ex-data ex)]
+      (pprint data))
     (when-let [stack (when ex (.-stack ex))]
       (println (chalk/gray stack)))))
 


### PR DESCRIPTION
- Add log/error for logging unexpected errors; begin to use it
- Clean up and unify some logging

This PR gives `log/error` some superpowers:

- If the first arg is a keyword, it will be treated as a "tag"
- The first exception will have its stack printed at the end, grayed out
- The ex-data of the exception (if any) will be pretty-printed
- The last map arg (if any) will be pretty-printed
