### PR TITLE
Add support for viewing a page "help" screen with keymaps

### DIFF
--- a/src/cli/gakki/cli/input.cljs
+++ b/src/cli/gakki/cli/input.cljs
@@ -24,7 +24,12 @@
                 :else
                 (reduce-kv
                   (fn [m k v]
-                    (assoc m k [name v]))
+                    (if (and (= :help k) (:help m))
+                      ; Special case: merge :help maps
+                      (update-in m [k 1] merge v)
+
+                      ; Normal case:
+                      (assoc m k [name v])))
                   h
                   owned)))
             {}

--- a/src/cli/gakki/cli/input.cljs
+++ b/src/cli/gakki/cli/input.cljs
@@ -1,10 +1,11 @@
 (ns gakki.cli.input
-  (:require [gakki.util.logging :as log]
+  (:require [archetype.util :refer [>evt]]
             ["ink" :as k]
             ["react" :rename {useEffect use-effect}]
             [reagent.impl.component :as reagent-impl]
             [gakki.cli.keys :refer [->key]]
-            [gakki.util.coll :refer [vec-dissoc]]))
+            [gakki.util.coll :refer [vec-dissoc]]
+            [gakki.util.logging :as log]))
 
 (defonce ^:private active-stack (atom []))
 (defonce ^:private handler (atom nil))
@@ -72,7 +73,7 @@
         (if (fn? handler)
           (handler the-key)
 
-          (when-let [[owner f] (get handler the-key)]
+          (if-let [[owner f] (get handler the-key)]
             (cond
               (and (fn? f) (= 0 (.-length f)))
               (f)
@@ -80,7 +81,11 @@
               :else
               (log/error "Handler to " the-key " was not a zero-arity fn."
                          "\n  Value: " f
-                         "\n  Registered: " owner)))))))
+                         "\n  Registered: " owner))
+
+            (when (and (= "?" the-key)
+                       (:help handler))
+              (>evt [:navigate! [:help (second (:help handler))]])))))))
 
   ; This is a functional component that doesn't render anything
   nil)

--- a/src/cli/gakki/cli/nav.cljs
+++ b/src/cli/gakki/cli/nav.cljs
@@ -2,10 +2,16 @@
   (:require [archetype.util :refer [>evt]]
             [gakki.cli.input :refer [use-input]]))
 
+(def ^:private help
+  {:header "Global Navigation"
+   "/" "Open Search"
+   :escape "Go back"})
+
 (defn global-nav []
   (use-input
     {"/" #(>evt [:navigate! [:search]])
-     :escape #(>evt [:navigate/back!])})
+     :escape #(>evt [:navigate/back!])
+     :help help})
 
   ; Nothing rendered here:
   nil)

--- a/src/cli/gakki/components/carousels.cljs
+++ b/src/cli/gakki/components/carousels.cljs
@@ -11,7 +11,9 @@
             [gakki.theme :as theme]))
 
 (def ^:private help
-  {"j" "Navigate cursor downward"})
+  {"j k" "Navigate cursor down / up"
+   "h l" "Navigate cursor left / right"
+   :return "Open/play the selected item."})
 
 (defn- category-item [{:keys [title selected?]}]
   [:> k/Box {:width :20%

--- a/src/cli/gakki/components/carousels.cljs
+++ b/src/cli/gakki/components/carousels.cljs
@@ -10,6 +10,9 @@
                                                  vertical-list]]
             [gakki.theme :as theme]))
 
+(def ^:private help
+  {"j" "Navigate cursor downward"})
+
 (defn- category-item [{:keys [title selected?]}]
   [:> k/Box {:width :20%
              :padding-x 1}
@@ -40,7 +43,8 @@
      "h" #(>evt [:carousel/navigate-row :left])
      "l" #(>evt [:carousel/navigate-row :right])
 
-     :return #(>evt [:carousel/open-selected])})
+     :return #(>evt [:carousel/open-selected])
+     :help help})
 
   (let [available-height (<sub [::subs/available-height])]
     [vertical-list

--- a/src/cli/gakki/components/player_mini.cljs
+++ b/src/cli/gakki/components/player_mini.cljs
@@ -6,6 +6,9 @@
 
 (def ^:private help
   {"q" "Show the queue"
+   :space "Play/Pause the current item"
+   "[ ]" "Decrease / Increase volume"
+
    :header "Player UI"})
 
 (defn- player-ui [playing volume playing?]

--- a/src/cli/gakki/components/player_mini.cljs
+++ b/src/cli/gakki/components/player_mini.cljs
@@ -4,12 +4,17 @@
             [gakki.cli.input :refer [use-input]]
             [gakki.theme :as theme]))
 
+(def ^:private help
+  {"q" "Show the queue"
+   :header "Player UI"})
+
 (defn- player-ui [playing volume playing?]
   (use-input
     {"q" #(>evt [:navigate! [:queue]])
      " " #(>evt [:player/play-pause])
      "[" #(>evt [:player/volume-inc -1])
-     "]" #(>evt [:player/volume-inc 1])})
+     "]" #(>evt [:player/volume-inc 1])
+     :help help})
 
   [:> k/Box {:flex-grow 1
              :flex-direction :row

--- a/src/cli/gakki/views.cljs
+++ b/src/cli/gakki/views.cljs
@@ -9,6 +9,7 @@
             [gakki.views.auth.ytm :as auth-ytm]
             [gakki.views.album :as album]
             [gakki.views.artist :as artist]
+            [gakki.views.help :as help]
             [gakki.views.home :as home]
             [gakki.views.playlist :as playlist]
             [gakki.views.queue :as queue]
@@ -22,6 +23,7 @@
    :auth/ytm #'auth-ytm/view
    :album #'album/view
    :artist #'artist/view
+   :help #'help/view
    :playlist #'playlist/view
    :queue #'queue/view
    :search #'search/view

--- a/src/cli/gakki/views/album.cljs
+++ b/src/cli/gakki/views/album.cljs
@@ -15,6 +15,12 @@
 (def max-album-title-length 20)
 (def max-artist-name-length 20)
 
+(def ^:private help
+  {"j k" "Navigate cursor down / up"
+   :return "Play the album"
+
+   :header "Album Page"})
+
 (defn track-row [{:keys [title selected?]}]
   [:> k/Box {:flex-direction :row}
    (if selected?
@@ -77,7 +83,8 @@
                     (>evt [:player/play-items (:items album)]))
          :escape #(if @state
                     (reset! state nil)
-                    (>evt [:navigate/back!]))})
+                    (>evt [:navigate/back!]))
+         :help help})
 
       [frame
        [album-header album]

--- a/src/cli/gakki/views/artist.cljs
+++ b/src/cli/gakki/views/artist.cljs
@@ -1,6 +1,7 @@
 (ns gakki.views.artist
   (:require [archetype.util :refer [<sub]]
             ["ink" :as k]
+            [gakki.cli.input :refer [use-input]]
             [gakki.components.carousels :refer [carousels]]
             [gakki.components.header :refer [header]]
             [gakki.components.frame :refer [frame]]
@@ -8,6 +9,8 @@
 
 (defn view [artist-id]
   (let [artist (<sub [:artist artist-id])]
+    (use-input {:help {:header "Artist Page"}})
+
     [frame
      [header
       [:> k/Text {:color theme/text-color-disabled}

--- a/src/cli/gakki/views/help.cljs
+++ b/src/cli/gakki/views/help.cljs
@@ -26,12 +26,10 @@
 
 (defn- help-section [{:keys [header] :as section}]
   [:<>
-   [:> k/Box {:flex-direction :row
-              :padding-bottom 1}
-    (if (string? header)
-      [:> k/Text header]
-      header)
-    [:> k/Text {:color theme/text-color-disabled} " / Help"]]
+   [:> k/Box {:flex-direction :row}
+    [:> k/Text {:underline true}
+     header
+     [:> k/Text {:color theme/text-color-disabled} " / Help"]]]
    [help-items (dissoc section :header)]
    [:> k/Newline]])
 

--- a/src/cli/gakki/views/help.cljs
+++ b/src/cli/gakki/views/help.cljs
@@ -1,13 +1,49 @@
 (ns gakki.views.help
-  (:require ["ink" :as k]
+  (:require [archetype.util :refer [>evt]]
+            ["ink" :as k]
+            [gakki.cli.input :refer [use-input]]
             [gakki.components.frame :refer [frame]]
+            [gakki.components.scrollable :refer [vertical-list]]
             [gakki.theme :as theme]))
 
-(defn view [{:keys [header] :as help}]
-  [frame
-   [:> k/Box {:flex-direction :row}
-    header
+(defn- keys-width-of [items]
+  (transduce
+    (map (comp count str first))
+    max
+    0
+    items))
+
+(defn- help-items [help]
+  (let [keys-width (inc (keys-width-of help))]
+    [:<>
+     (for [[k desc] (sort-by (comp str first) help)]
+       ^{:key k}
+       [:> k/Box {:flex-direction :row}
+        [:> k/Box {:width keys-width}
+         [:> k/Text {:bold true} k]]
+        [:> k/Text " "]
+        [:> k/Text desc]])]))
+
+(defn- help-section [{:keys [header] :as section}]
+  [:<>
+   [:> k/Box {:flex-direction :row
+              :padding-bottom 1}
+    (if (string? header)
+      [:> k/Text header]
+      header)
     [:> k/Text {:color theme/text-color-disabled} " / Help"]]
-   [:> k/Newline]
-   [:> k/Text (str (dissoc help :header))]
-   ])
+   [help-items (dissoc section :header)]
+   [:> k/Newline]])
+
+(defn view [help-sections]
+  (use-input
+    (fn [k]
+      (case k
+        :escape (>evt [:navigate/back!])
+        nil)))
+
+  [frame
+   [vertical-list
+    :items (reverse help-sections)  ; Last-registered is most relevant
+    :render help-section
+    :key-fn :header]])

--- a/src/cli/gakki/views/help.cljs
+++ b/src/cli/gakki/views/help.cljs
@@ -1,0 +1,13 @@
+(ns gakki.views.help
+  (:require ["ink" :as k]
+            [gakki.components.frame :refer [frame]]
+            [gakki.theme :as theme]))
+
+(defn view [{:keys [header] :as help}]
+  [frame
+   [:> k/Box {:flex-direction :row}
+    header
+    [:> k/Text {:color theme/text-color-disabled} " / Help"]]
+   [:> k/Newline]
+   [:> k/Text (str (dissoc help :header))]
+   ])

--- a/src/cli/gakki/views/home.cljs
+++ b/src/cli/gakki/views/home.cljs
@@ -12,7 +12,7 @@
 (defn- initialized []
   (use-input
     {"r" #(>evt [:providers/refresh!])
-     :help (assoc help :header [header "Gakki Home"])})
+     :help (assoc help :header "Gakki Home")})
 
   [frame
    [header "Gakki Home"]

--- a/src/cli/gakki/views/home.cljs
+++ b/src/cli/gakki/views/home.cljs
@@ -6,9 +6,13 @@
             [gakki.components.carousels :refer [carousels]]
             [gakki.views.splash :as splash]))
 
+(def ^:private help
+  {"r" "Reload home screen items"})
+
 (defn- initialized []
   (use-input
-    {"r" #(>evt [:providers/refresh!])})
+    {"r" #(>evt [:providers/refresh!])
+     :help (assoc help :header [header "Gakki Home"])})
 
   [frame
    [header "Gakki Home"]

--- a/src/cli/gakki/views/playlist.cljs
+++ b/src/cli/gakki/views/playlist.cljs
@@ -1,6 +1,7 @@
 (ns gakki.views.playlist
   (:require [archetype.util :refer [>evt <sub]]
             ["ink" :as k]
+            [gakki.cli.input :refer [use-input]]
             [gakki.components.header :refer [header]]
             [gakki.theme :as theme]
             [gakki.views.queue :refer [track-list]]))
@@ -12,6 +13,7 @@
    (:title playlist)])
 
 (defn view [id]
+  (use-input {:help {:header "Playlist"}})
   (let [playlist (<sub [:playlist id])]
     [:f> track-list
      :items (<sub [:playlist/items-with-state id])

--- a/src/cli/gakki/views/queue.cljs
+++ b/src/cli/gakki/views/queue.cljs
@@ -15,6 +15,9 @@
 (def ^:private preferred-max-queue-height 20)
 (def ^:private max-track-length-perc 0.4)
 
+(def ^:private help
+  {"j" "Move cursor down vertically"})
+
 (defn queue-item [{:keys [selected? current?] :as track}]
   ; subtract an extra 2 for the indicator space
   ; and 8 for the separators (the arrow is wider than it looks)
@@ -98,7 +101,9 @@
                     (on-index-selected index)
 
                     (when on-whole-list-selected
-                      (on-whole-list-selected)))})
+                      (on-whole-list-selected)))
+
+         :help (assoc help :header header)})
 
       [frame
        header

--- a/src/cli/gakki/views/queue.cljs
+++ b/src/cli/gakki/views/queue.cljs
@@ -16,7 +16,9 @@
 (def ^:private max-track-length-perc 0.4)
 
 (def ^:private help
-  {"j" "Move cursor down vertically"})
+  {"j" "Move cursor down vertically"
+   "k" "Move cursor up vertically"
+   :return "Start playing the playlist"})
 
 (defn queue-item [{:keys [selected? current?] :as track}]
   ; subtract an extra 2 for the indicator space
@@ -103,7 +105,7 @@
                     (when on-whole-list-selected
                       (on-whole-list-selected)))
 
-         :help (assoc help :header header)})
+         :help help})
 
       [frame
        header
@@ -117,6 +119,7 @@
         ]])))
 
 (defn view []
+  (use-input {:help {:header "Queue"}})
   (let [queue (<sub [:queue/items-with-state])]
     [:f> track-list
      :items queue

--- a/src/cli/gakki/views/search_results.cljs
+++ b/src/cli/gakki/views/search_results.cljs
@@ -2,6 +2,7 @@
   (:require [archetype.util :refer [<sub]]
             ["ink" :as k]
             ["ink-spinner" :default Spinner]
+            [gakki.cli.input :refer [use-input]]
             [gakki.components.carousels :refer [carousels]]
             [gakki.components.frame :refer [frame]]
             [gakki.components.header :refer [header]]
@@ -32,6 +33,8 @@
   [:f> carousels])
 
 (defn view [query]
+  (use-input {:help {:header "Search"}})
+
   [frame
    [header
     [:> k/Text {:color theme/text-color-disabled} "Search / "]

--- a/src/test/gakki/cli/input_test.cljs
+++ b/src/test/gakki/cli/input_test.cljs
@@ -1,0 +1,21 @@
+(ns gakki.cli.input-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [gakki.cli.input :refer [apply-help-map]]))
+
+(deftest apply-help-map-test
+  (testing "Don't overwrite an existing header"
+    (is (= ["source" [{:header "First"}
+                      {:header "Second"}]]
+           (apply-help-map
+             ["source" [{:header "First"}]]
+             ""
+             {:header "Second"}))))
+
+  (testing ":header-less items create a new section"
+    (is (= ["source" [{:header "First"}
+                      {"key" "description"}]]
+           (apply-help-map
+             ["source" [{:header "First"}]]
+             ""
+             {"key" "description"})))))
+


### PR DESCRIPTION
- Scaffold out support for viewing screen-specific help
- Merge help from all registered inputs
- Refactor help pages to group keys into sections by "header"
- Fill out help descriptions
- Make help rendering slightly more compact

<img width="682" alt="Screen Shot 2021-06-14 at 8 37 28 PM" src="https://user-images.githubusercontent.com/816150/121975733-5742b780-cd50-11eb-8591-7d9376f27ec9.png">