### PR TITLE
Provide track duration/timestamp to native + support seek

### DIFF
--- a/macos/gakki/gakki.xcodeproj/project.pbxproj
+++ b/macos/gakki/gakki.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6565346C267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565346B267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift */; };
 		65C58C7F265862B2001C4796 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C58C7E265862B1001C4796 /* Command.swift */; };
 		65C58C812658652F001C4796 /* convertFromKebabCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C58C802658652F001C4796 /* convertFromKebabCase.swift */; };
 		65C58C84265868AE001C4796 /* CommandHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C58C83265868AE001C4796 /* CommandHandler.swift */; };
@@ -39,6 +40,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6565346B267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MPNowPlayingInfoCenter+Extensions.swift"; sourceTree = "<group>"; };
 		65C58C7E265862B1001C4796 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		65C58C802658652F001C4796 /* convertFromKebabCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = convertFromKebabCase.swift; sourceTree = "<group>"; };
 		65C58C83265868AE001C4796 /* CommandHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandHandler.swift; sourceTree = "<group>"; };
@@ -85,6 +87,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6565346A267A442600679CA5 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				6565346B267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		65C58C8226586536001C4796 /* Parsing */ = {
 			isa = PBXGroup;
 			children = (
@@ -125,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				B6B19AC2265ABF88008635AC /* Commands */,
+				6565346A267A442600679CA5 /* Extensions */,
 				65C58C85265868B7001C4796 /* Model */,
 				65C58C8226586536001C4796 /* Parsing */,
 				65C58C83265868AE001C4796 /* CommandHandler.swift */,
@@ -311,6 +322,7 @@
 				B6B19AC4265ABF88008635AC /* Auth.swift in Sources */,
 				65C58C8726586B0C001C4796 /* IPC.swift in Sources */,
 				65C58C812658652F001C4796 /* convertFromKebabCase.swift in Sources */,
+				6565346C267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/gakki/gakki/AppDelegate.swift
+++ b/macos/gakki/gakki/AppDelegate.swift
@@ -95,5 +95,38 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             IPC.send(["type": "media", "event": "next-track"])
             return .success
         })
+
+        let seek = commandCenter.changePlaybackPositionCommand
+        seek.isEnabled = true
+        seek.addTarget { event in
+            if let ev = event as? MPChangePlaybackPositionCommandEvent {
+                IPC.send([
+                    "type": "media",
+                    "event": "seek",
+                    "time": ev.positionTime,
+                ])
+            }
+
+            return .success
+        }
+
+        commandCenter.skipForwardCommand.handleSeekEvent(seekDirection: 1.0)
+        commandCenter.skipBackwardCommand.handleSeekEvent(seekDirection: -1.0)
+    }
+}
+
+extension MPSkipIntervalCommand {
+    func handleSeekEvent(seekDirection: Double) {
+        isEnabled = true
+        addTarget(handler: { event in
+            if let ev = event as? MPSkipIntervalCommandEvent {
+                IPC.send([
+                    "type": "media",
+                    "event": "seek",
+                    "relative": seekDirection * ev.interval,
+                ])
+            }
+            return .success
+        })
     }
 }

--- a/macos/gakki/gakki/AppDelegate.swift
+++ b/macos/gakki/gakki/AppDelegate.swift
@@ -100,6 +100,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         seek.isEnabled = true
         seek.addTarget { event in
             if let ev = event as? MPChangePlaybackPositionCommandEvent {
+                MPNowPlayingInfoCenter.default().setCurrentTime(ev.positionTime)
                 IPC.send([
                     "type": "media",
                     "event": "seek",

--- a/macos/gakki/gakki/AppDelegate.swift
+++ b/macos/gakki/gakki/AppDelegate.swift
@@ -110,8 +110,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return .success
         }
 
-        commandCenter.skipForwardCommand.handleSeekEvent(seekDirection: 1.0)
-        commandCenter.skipBackwardCommand.handleSeekEvent(seekDirection: -1.0)
+        // NOTE: This code is kept around for reference, but is disabled for
+        // now. If we enable these commands, we seem to lose the next/prev
+        // track buttons in the UI, and there are also some issues around
+        // updating the current timestamp when they fire... so it's easiest
+        // to just not use them, and rely on the absolute seek command.
+        // commandCenter.skipForwardCommand.handleSeekEvent(seekDirection: 1.0)
+        // commandCenter.skipBackwardCommand.handleSeekEvent(seekDirection: -1.0)
     }
 }
 

--- a/macos/gakki/gakki/CommandHandler.swift
+++ b/macos/gakki/gakki/CommandHandler.swift
@@ -111,6 +111,12 @@ struct CommandHandler {
         if let inputState = command.state,
         let state = commandToPlaybackState[inputState] {
             MPNowPlayingInfoCenter.default().playbackState = state
+
+            if let time = command.currentTime {
+                MPNowPlayingInfoCenter.default().nowPlayingInfo?.merge([
+                    MPNowPlayingInfoPropertyElapsedPlaybackTime: time,
+                ], uniquingKeysWith: { _, new in new })
+            }
         }
     }
 

--- a/macos/gakki/gakki/CommandHandler.swift
+++ b/macos/gakki/gakki/CommandHandler.swift
@@ -113,9 +113,7 @@ struct CommandHandler {
             MPNowPlayingInfoCenter.default().playbackState = state
 
             if let time = command.currentTime {
-                MPNowPlayingInfoCenter.default().nowPlayingInfo?.merge([
-                    MPNowPlayingInfoPropertyElapsedPlaybackTime: time,
-                ], uniquingKeysWith: { _, new in new })
+                MPNowPlayingInfoCenter.default().setCurrentTime(time)
             }
         }
     }

--- a/macos/gakki/gakki/CommandHandler.swift
+++ b/macos/gakki/gakki/CommandHandler.swift
@@ -76,6 +76,10 @@ struct CommandHandler {
             MPMediaItemPropertyArtist: command.artist ?? "",
         ]
 
+        if let duration = command.duration, duration > 0 {
+            info[MPMediaItemPropertyPlaybackDuration] = duration
+        }
+
         if let rawImageUrl = command.imageUrl,
         let imageUrl = URL(string: rawImageUrl) {
 

--- a/macos/gakki/gakki/Extensions/MPNowPlayingInfoCenter+Extensions.swift
+++ b/macos/gakki/gakki/Extensions/MPNowPlayingInfoCenter+Extensions.swift
@@ -1,0 +1,20 @@
+//
+//  MPNowPlayingInfoCenter+Extensions.swift
+//  gakki
+//
+//  Created by Daniel Leong on 6/16/21.
+//
+
+import MediaPlayer
+
+extension MPNowPlayingInfoCenter {
+    func updateNowPlayingInfo(_ newValues: [String: Any]) {
+        self.nowPlayingInfo?.merge(newValues, uniquingKeysWith: { _, new in new })
+    }
+
+    func setCurrentTime(_ currentTime: Double) {
+        updateNowPlayingInfo([
+            MPNowPlayingInfoPropertyElapsedPlaybackTime: currentTime,
+        ])
+    }
+}

--- a/macos/gakki/gakki/Model/Command.swift
+++ b/macos/gakki/gakki/Model/Command.swift
@@ -30,7 +30,7 @@ struct Command: Codable {
 
     // .setState:
     var state: State?
-    var currentTime: Float?
+    var currentTime: Double?
 
     // .setNowPlaying:
     var title: String?

--- a/macos/gakki/gakki/Model/Command.swift
+++ b/macos/gakki/gakki/Model/Command.swift
@@ -30,6 +30,7 @@ struct Command: Codable {
 
     // .setState:
     var state: State?
+    var currentTime: Float?
 
     // .setNowPlaying:
     var title: String?

--- a/macos/gakki/gakki/Model/Command.swift
+++ b/macos/gakki/gakki/Model/Command.swift
@@ -35,6 +35,7 @@ struct Command: Codable {
     var title: String?
     var artist: String?
     var imageUrl: String?
+    var duration: Int?
 }
 
 extension Command {

--- a/src/core/gakki/accounts/ytm/playable.cljs
+++ b/src/core/gakki/accounts/ytm/playable.cljs
@@ -22,6 +22,7 @@
    *may* be nil for public (not auth-required) videos."
   [account id]
   (track/create-playable
+    id
     (pcm/create-caching-source
       (str "ytm." id)
       #(youtube-id->stream account id))))

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -332,6 +332,18 @@
        :native/set-state! :paused})))
 
 (reg-event-fx
+  :player/seek-by
+  [trim-v]
+  (fn [_ [relative-seconds]]
+    {:player/seek-by! relative-seconds}))
+
+(reg-event-fx
+  :player/seek-to
+  [trim-v]
+  (fn [_ [timestamp-seconds]]
+    {:player/seek-to! timestamp-seconds}))
+
+(reg-event-fx
   :player/set-volume
   [trim-v
    (path :player)

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -246,6 +246,19 @@
             [:dispatch [:player/open entity]])]}))
 
 (reg-event-fx
+  :player/on-playback-config-resolved
+  [trim-v (path :player :current)]
+  (fn [{current :db} [id {duration-ms :duration}]]
+    (let [duration-seconds (js/Math.ceil (/ duration-ms 1000))]
+      (when (and (= id (:id current))
+                 (not= duration-seconds (:duration current)))
+        (log/player "Providing duration" duration-seconds
+                    " (was " (:duration current) ") for track #" id)
+        (let [with-duration (assoc current :duration duration-seconds)]
+          {:db with-duration
+           :native/set-now-playing! with-duration})))))
+
+(reg-event-fx
   :player/play-items
   [trim-v (path :player :queue)]
   (fn [_ [items ?selected-index]]

--- a/src/core/gakki/fx.cljs
+++ b/src/core/gakki/fx.cljs
@@ -160,6 +160,8 @@
 (reg-fx :player/pause! player/pause!)
 (reg-fx :player/play! player/play!)
 (reg-fx :player/prepare! player/prepare!)
+(reg-fx :player/seek-by! player/seek-by!)
+(reg-fx :player/seek-to! player/seek-to!)
 (reg-fx :player/set-volume! player/set-volume!)
 (reg-fx :player/unpause! player/unpause!)
 

--- a/src/core/gakki/native/macos.cljs
+++ b/src/core/gakki/native/macos.cljs
@@ -140,10 +140,12 @@
 
      {:title 'title'
       :artist 'artist name'
+      :duration duartion-seconds
       :image-url 'optional url'}"
   [now-playing]
-  (send! (assoc now-playing
-                :type :set-now-playing))
+  (log/debug "set-now-playing!" now-playing)
+  (send! (-> now-playing
+             (assoc :type :set-now-playing)))
   (set-state! :playing))
 
 

--- a/src/core/gakki/native/macos.cljs
+++ b/src/core/gakki/native/macos.cljs
@@ -3,10 +3,11 @@
             ["child_process" :refer [ChildProcess spawn]]
             [clojure.string :as str]
             [cognitect.transit :as t]
-            [gakki.util.logging :as log]
             ["path" :rename {join path-join}]
             [promesa.core :as p]
-            ["stream" :refer [Readable]]))
+            ["stream" :refer [Readable]]
+            [gakki.player :as player]
+            [gakki.util.logging :as log]))
 
 (def ^:private native-exe-path
   "./macos/gakki/build/Release/gakki.app/Contents/MacOS/gakki")
@@ -37,13 +38,18 @@
                  raw-message
                  e))))
 
-(defn- handle-media-event [{:keys [event]}]
+(defn- handle-media-event [{:keys [event] :as ev}]
   (case event
     :toggle (>evt [:player/play-pause])
     :next-track (>evt [:player/next-in-queue])
     :previous-track (>evt [:player/rewind-or-prev-in-queue])
     :pause (>evt [:player/pause])
     :play (>evt [:player/play])
+    :seek (cond
+            ; NOTE: macOS times/intervals are all in seconds
+            (:relative ev) (>evt [:player/seek-by (:relative ev)])
+            (:time ev) (>evt [:player/seek-to (:time ev)])
+            :else (log/error :native "Unexpected seek mechanism: " ev))
 
     (log/error :native "TODO: handle media event: " event)))
 
@@ -133,6 +139,7 @@
 
 (defn set-state! [state]
   (send! {:type :set-state
+          :current-time (player/current-time)
           :state state}))
 
 (defn set-now-playing!
@@ -140,7 +147,7 @@
 
      {:title 'title'
       :artist 'artist name'
-      :duration duartion-seconds
+      :duration duration-seconds
       :image-url 'optional url'}"
   [now-playing]
   (log/debug "set-now-playing!" now-playing)

--- a/src/core/gakki/player/track.cljs
+++ b/src/core/gakki/player/track.cljs
@@ -7,19 +7,19 @@
             [gakki.player.track.events :as events]
             [promesa.core :as p]))
 
-(defn create-with-events [^IPCMSource pcm-source, ^EventEmitter events]
+(defn create-with-events [id, ^IPCMSource pcm-source, ^EventEmitter events]
   (-> pcm-source
       (pcm/prepare)
       (p/catch (fn [e]
                  ((log/of :track) "Error preparing " pcm-source ": " e)
                  (.emit events "end"))))
   (events/wrap
-    (track/create pcm-source)
+    (track/create id pcm-source)
     events))
 
 ; TODO: We probably want to refactor this out and use AudioTrack directly...
-(defn create-playable [^IPCMSource pcm-source]
-  (create-with-events pcm-source (EventEmitter.)))
+(defn create-playable [id ^IPCMSource pcm-source]
+  (create-with-events id pcm-source (EventEmitter.)))
 
 (defonce ^:private test-track (atom nil))
 

--- a/src/core/gakki/player/track/core.cljs
+++ b/src/core/gakki/player/track/core.cljs
@@ -9,6 +9,7 @@
 (def ^:private log (log/of :player/track))
 
 (defprotocol IAudioTrack
+  (id [this])
   (close [this])
   (read-config [this])
   (seek [this timestamp-seconds]))
@@ -23,6 +24,8 @@
     (-write writer (.toString this)))
 
   IAudioTrack
+  (id [_this] id)
+
   (close [_this]
     (swap! state (fn [{:keys [clip] :as state}]
                    (when clip

--- a/src/core/gakki/player/track/events.cljs
+++ b/src/core/gakki/player/track/events.cljs
@@ -62,6 +62,7 @@
     (-write writer (.toString this)))
 
   IAudioTrack
+  (id [_this] (track/id base))
   (close [_this] (track/close base))
   (read-config [_this] (track/read-config base))
   (seek [this timestamp-seconds]

--- a/src/core/gakki/player/track/events.cljs
+++ b/src/core/gakki/player/track/events.cljs
@@ -66,6 +66,8 @@
   (read-config [_this] (track/read-config base))
   (seek [this timestamp-seconds]
     (track/seek base timestamp-seconds)
+    ; NOTE: clip/current-time doesn't seem to be reliable here for some reason,
+    ; so we just pass the exact timestamp to use:
     (restart-event-timers this timestamp-seconds))
 
   IPlayable

--- a/src/core/gakki/player/track/events.cljs
+++ b/src/core/gakki/player/track/events.cljs
@@ -8,8 +8,13 @@
 
 (def ^:private log (log/of :player.track/events))
 
-(defn- enqueue-end-notification [^EventEmitter events config ^IAudioClip clip]
-  (let [current-time-ms (* (clip/current-time clip) 1000)
+(declare EventfulAudioTrack)
+
+(defn- enqueue-end-notification
+  [^EventEmitter events config ^IAudioClip clip current-timestamp-seconds]
+  (let [current-time-ms (* (or current-timestamp-seconds
+                               (clip/current-time clip))
+                           1000)
         end-timeout (max 0
                          (- (:duration config)
                             current-time-ms
@@ -32,6 +37,21 @@
       (js/clearTimeout end-timer)
       (js/clearTimeout ending-timer))))
 
+(defn- restart-event-timers
+  ([^EventfulAudioTrack eventful-track] (restart-event-timers eventful-track nil))
+  ([^EventfulAudioTrack eventful-track current-timestamp-seconds]
+   (p/let [config (track/read-config eventful-track)]
+     (swap! (.-state eventful-track)
+            (fn [{:keys [clear-timer] :as old-state}]
+              (when clear-timer
+                (clear-timer))
+              (assoc old-state :clear-timer
+                     (enqueue-end-notification
+                       (.-events eventful-track)
+                       config
+                       eventful-track
+                       current-timestamp-seconds)))))))
+
 (deftype EventfulAudioTrack [^IAudioTrack base, ^EventEmitter events, state]
   Object
   (toString [_this]
@@ -44,7 +64,9 @@
   IAudioTrack
   (close [_this] (track/close base))
   (read-config [_this] (track/read-config base))
-  (seek [_this timestamp-seconds] (track/seek base timestamp-seconds))
+  (seek [this timestamp-seconds]
+    (track/seek base timestamp-seconds)
+    (restart-event-timers this timestamp-seconds))
 
   IPlayable
   (close [this] (clip/close this))
@@ -62,15 +84,7 @@
 
   (play [this]
     (when-not (clip/playing? this)
-      (p/let [config (track/read-config this)]
-        (swap! state (fn [{:keys [clear-timer] :as old-state}]
-                       (when clear-timer
-                         (clear-timer))
-                       (assoc old-state :clear-timer
-                              (enqueue-end-notification
-                                events
-                                config
-                                this)))))
+      (restart-event-timers this)
       (clip/play base)))
 
   (pause [this]


### PR DESCRIPTION
<img width="346" alt="Screen Shot 2021-06-16 at 10 47 55 AM" src="https://user-images.githubusercontent.com/816150/122241130-50bb5980-ce90-11eb-8251-52c47537bc17.png">

TODO:
- [x] More consistently provide `:duration` to native. Not all endpoints provide it, currently, but we are typically able to resolve it to handle the "continue playback" functionality, so we ought to be able to pass that along at some 