### PR TITLE
Resample audio if necessary to suit output device

### DIFF
--- a/src/core/gakki/player/decode.cljs
+++ b/src/core/gakki/player/decode.cljs
@@ -35,14 +35,14 @@
                     ((log/of :player/decode)
                      "No optimized decoder for " codec
                      "; falling back to ffmpeg")
-                    (-> (prism/FFmpeg.
-                          (j/lit
-                            {:args [:-loglevel "0"
-                                    :-ac (:channels config)
-                                    :-i "-"
-                                    :-f "s16le"
-                                    :-acodec "pcm_s16le"
-                                    :-ac (:channels config)]})))))
+                    (prism/FFmpeg.
+                      (j/lit
+                        {:args [:-loglevel "0"
+                                :-ac (:channels config)
+                                :-i "-"
+                                :-f "s16le"
+                                :-acodec "pcm_s16le"
+                                :-ac (:channels config)]}))))
 
         demuxed (if demuxer
                   (.pipe stream demuxer)

--- a/src/core/gakki/player/decode.cljs
+++ b/src/core/gakki/player/decode.cljs
@@ -1,7 +1,8 @@
 (ns gakki.player.decode
   (:require [applied-science.js-interop :as j]
-            [gakki.const :as const]
             ["prism-media" :as prism]
+            ["stream" :refer [Readable]]
+            [gakki.const :as const]
             [gakki.player.stream.chunking :as chunking]
             [gakki.util.logging :as log]))
 
@@ -15,7 +16,7 @@
     :container \"webm\"  ; eg
     :codec \"opus\"}     ; eg
    "
-  [{:keys [container codec] :as config} ^js stream]
+  [{:keys [container codec] :as config} ^Readable stream]
   (let [demuxer (case container
                   "ogg" (prism/opus.OggDemuxer.)
                   "webm" (case codec

--- a/src/core/gakki/player/decode.cljs
+++ b/src/core/gakki/player/decode.cljs
@@ -51,9 +51,4 @@
 
     ; Ensure that the decoded data is chunked appropriately to match the
     ; configured :frame-size (important to make RtAudio/Audify happy)
-    (if-let [frame-size (:frame-size config)]
-      (-> decoded
-          (chunking/nbytes (* (:channels config)
-                              const/bytes-per-sample
-                              frame-size)))
-      decoded)))
+    (chunking/nbytes-from-config decoded config)))

--- a/src/core/gakki/player/pcm/disk.cljs
+++ b/src/core/gakki/player/pcm/disk.cljs
@@ -2,6 +2,7 @@
   (:require ["fs" :rename {createReadStream create-read-stream}]
             ["fs/promises" :as fs]
             ["path" :as path]
+            ["stream" :refer [Readable]]
             [promesa.core :as p]
             [gakki.player.pcm.core :as pcm :refer [IPCMSource]]
             [gakki.player.analyze :as analyze]
@@ -10,7 +11,7 @@
 (defn- open-stream [path]
   (p/create
     (fn [p-resolve p-reject]
-      (let [s (create-read-stream path)]
+      (let [^Readable s (create-read-stream path)]
         (doto s
           (.on "error" p-reject)
           (.on "open" #(p-resolve s)))))))

--- a/src/core/gakki/player/stream/chunking.cljs
+++ b/src/core/gakki/player/stream/chunking.cljs
@@ -1,5 +1,6 @@
 (ns gakki.player.stream.chunking
-  (:require ["stream" :refer [Transform Readable]]))
+  (:require ["stream" :refer [Transform Readable]]
+            [gakki.const :as const]))
 
 (defn- concat-buffer [original to-concat]
   (js/Buffer.concat #js [original to-concat]))
@@ -26,3 +27,15 @@
    which chunks its input into Buffers of size divisible by `n`."
   [^Readable input, n]
   (.pipe input (create-nbytes-chunking-transform n)))
+
+(defn ^Readable nbytes-from-config
+  "Uses the :frame-size of `config` (if provided) to chunk via `nbytes`"
+  [^Readable input, config]
+  (if-let [frame-size (:frame-size config)]
+    (-> input
+        (nbytes (* (:channels config)
+                   const/bytes-per-sample
+                   frame-size)))
+    input))
+
+

--- a/src/core/gakki/player/stream/resampling.cljs
+++ b/src/core/gakki/player/stream/resampling.cljs
@@ -2,8 +2,7 @@
   (:require [applied-science.js-interop :as j]
             [gakki.player.stream.chunking :as chunking]
             ["prism-media" :as prism]
-            ["stream" :refer [Readable]]
-    ))
+            ["stream" :refer [Readable]]))
 
 (defn convert-pcm-config [^Readable stream, old-config new-config]
   (let [transform (prism/FFmpeg.

--- a/src/core/gakki/player/stream/resampling.cljs
+++ b/src/core/gakki/player/stream/resampling.cljs
@@ -1,0 +1,21 @@
+(ns gakki.player.stream.resampling
+  (:require [applied-science.js-interop :as j]
+            [gakki.player.stream.chunking :as chunking]
+            ["prism-media" :as prism]
+            ["stream" :refer [Readable]]
+    ))
+
+(defn convert-pcm-config [^Readable stream, old-config new-config]
+  (let [transform (-> (prism/FFmpeg.
+                        (j/lit
+                          {:args [:-loglevel "0"
+                                  :-f "s16le"
+                                  :-ac (:channels old-config)
+                                  :-ar (:sample-rate old-config)
+                                  :-i "-"
+                                  :-ac (:channels new-config)
+                                  :-ar (:sample-rate new-config)
+                                  :-f "s16le"]})))]
+    (-> stream
+        (.pipe transform)
+        (chunking/nbytes-from-config new-config))))

--- a/src/core/gakki/player/stream/resampling.cljs
+++ b/src/core/gakki/player/stream/resampling.cljs
@@ -6,16 +6,16 @@
     ))
 
 (defn convert-pcm-config [^Readable stream, old-config new-config]
-  (let [transform (-> (prism/FFmpeg.
-                        (j/lit
-                          {:args [:-loglevel "0"
-                                  :-f "s16le"
-                                  :-ac (:channels old-config)
-                                  :-ar (:sample-rate old-config)
-                                  :-i "-"
-                                  :-ac (:channels new-config)
-                                  :-ar (:sample-rate new-config)
-                                  :-f "s16le"]})))]
+  (let [transform (prism/FFmpeg.
+                    (j/lit
+                      {:args [:-loglevel "0"
+                              :-f "s16le"
+                              :-ac (:channels old-config)
+                              :-ar (:sample-rate old-config)
+                              :-i "-"
+                              :-ac (:channels new-config)
+                              :-ar (:sample-rate new-config)
+                              :-f "s16le"]}))]
     (-> stream
         (.pipe transform)
         (chunking/nbytes-from-config new-config))))


### PR DESCRIPTION
Fixes #22

Output devices apparently don't necessarily support all common audio sample rates—for example, my bluetooth headphones only support 16kHz and 48kHz, according to Audify/RtAudio. Some files we get from providers will not necessarily fit these rates, however, so this PR uses FFmpeg to resample such sources to fit the "preferred" sample rate of the device.

Our current model decodes files to PCM in their original format and passes it to AudioClip, which talks to the output device. This is nice and clean, but it does mean that we miss a potential optimization: for example, if we had the output device config ahead of time, for the case when we're already decoding the file with FFmpeg we could avoid an additional pass through FFmpeg if we then *also* need to resample. In practice this doesn't seem to be a noticeable issue, nor worth breaking the separation of concerns we have, but if it becomes a problem in the future we could revisit whose responsibility it is to perform the decode.
