### PR TITLE
Implement cache management

### DIFF
--- a/src/core/gakki/const.cljs
+++ b/src/core/gakki/const.cljs
@@ -1,9 +1,12 @@
-(ns gakki.const)
+(ns gakki.const
+  (:require [gakki.util.bytesize :as bytesize]))
 
 (def debug? goog/DEBUG)
 
 (def max-volume-int 10)
 (def suppressed-volume-percent 0.20)
+
+(def default-cache-size (bytesize/parse "1G"))
 
 ; TODO Not sure how this should be determined; maybe it's just a buffer size and
 ; doesn't really matter what value it is...

--- a/src/core/gakki/db.cljs
+++ b/src/core/gakki/db.cljs
@@ -1,4 +1,5 @@
-(ns gakki.db)
+(ns gakki.db
+  (:require [gakki.const :as const]))
 
 (def default-integrations
   {:discord {}})
@@ -7,3 +8,6 @@
   {:page [:home]
    :backstack []
    :accounts nil})
+
+(def default-prefs
+  {:cache.size const/default-cache-size})

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -11,6 +11,8 @@
             [gakki.util.logging :as log]
             [gakki.util.media :refer [category-id]]))
 
+(def ^:private inject-sub (partial inject-cofx ::inject/sub))
+
 (reg-event-fx
   ::initialize-db
   (fn [_ _]
@@ -152,7 +154,7 @@
 (reg-event-fx
   :carousel/navigate-categories
   [trim-v carousel-path
-   (inject-cofx ::inject/sub [:carousel/categories])]
+   (inject-sub [:carousel/categories])]
   (fn [{categories :carousel/categories} [direction]]
     (let [delta (case direction
                   :up -1
@@ -168,8 +170,8 @@
 (reg-event-fx
   :carousel/navigate-row
   [trim-v carousel-path
-   (inject-cofx ::inject/sub [:carousel/selection])
-   (inject-cofx ::inject/sub [:carousel/categories])]
+   (inject-sub [:carousel/selection])
+   (inject-sub [:carousel/categories])]
   (fn [{categories :carousel/categories selections :carousel/selection}
        [direction]]
     (let [{:keys [items] :as category} (or (when-let [id (:category selections)]
@@ -191,7 +193,7 @@
 
 (reg-event-fx
   :carousel/open-selected
-  [trim-v carousel-path (inject-cofx ::inject/sub [:page])]
+  [trim-v carousel-path (inject-sub [:page])]
   (fn [{{:keys [selected]} :carousel} _]
     (when selected
       {:dispatch [:player/open selected]})))
@@ -273,7 +275,7 @@
 
 (reg-event-fx
   ::set-current-playable
-  [trim-v (inject-cofx ::inject/sub [:player/volume-percent])]
+  [trim-v (inject-sub [:player/volume-percent])]
   (fn [{:keys [db] volume-percent :player/volume-percent} [playable]]
     ((log/of :events/set-current-playable) "set playable <- " playable "@" volume-percent)
     {:db (-> db
@@ -360,7 +362,7 @@
   :player/set-volume
   [trim-v
    (path :player)
-   (inject-cofx ::inject/sub [:player/volume-suppress-amount])]
+   (inject-sub [:player/volume-suppress-amount])]
   (fn [{player :db suppress-amount :player/volume-suppress-amount} [new-volume]]
     ; NOTE: new-volume should be in [0..max-volume-int]
     (let [new-volume (-> new-volume
@@ -416,6 +418,21 @@
   [trim-v]
   (fn [{:keys [db]} [event]]
     (handle-player-event db event)))
+
+
+; ======= Cache management ================================
+
+(reg-event-fx
+  :cache/download-completed
+  [trim-v (inject-sub [:prefs :cache.size])]
+  (fn [{cache-size :prefs} [path]]
+    (println "TODO check cache vs " cache-size
+             "downloaded: " path)))
+
+(reg-event-fx
+  :cache/file-accessed
+  [trim-v]
+  (fn [_ [path]]))
 
 
 ; ======= Integrations ====================================

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -426,13 +426,14 @@
   :cache/download-completed
   [trim-v (inject-sub [:prefs :cache.size])]
   (fn [{cache-size :prefs} [path]]
-    (println "TODO check cache vs " cache-size
-             "downloaded: " path)))
+    {:cache/download-completed {:cache-size cache-size
+                                :path path}}))
 
 (reg-event-fx
   :cache/file-accessed
   [trim-v]
-  (fn [_ [path]]))
+  (fn [_ [path]]
+    {:cache/file-accessed path}))
 
 
 ; ======= Integrations ====================================

--- a/src/core/gakki/fx.cljs
+++ b/src/core/gakki/fx.cljs
@@ -7,6 +7,7 @@
             [gakki.integrations :as integrations]
             [gakki.native :as native]
             [gakki.player :as player]
+            [gakki.player.cache :as cache]
             [gakki.util.loading :refer [with-loading-promise]]
             [gakki.util.logging :as log]))
 
@@ -164,6 +165,23 @@
 (reg-fx :player/seek-to! player/seek-to!)
 (reg-fx :player/set-volume! player/set-volume!)
 (reg-fx :player/unpause! player/unpause!)
+
+
+; ======= Cache ===========================================
+
+(defonce ^:private player-cache (atom nil))
+
+(reg-fx
+  :cache/file-accessed
+  (fn [path]
+    (when-let [cache @player-cache]
+      (cache/on-file-accessed cache path))))
+
+(reg-fx
+  :cache/download-completed
+  (fn [{:keys [cache-size path]}]
+    (let [cache (swap! player-cache cache/ensure-sized cache-size)]
+      (cache/on-file-created cache path))))
 
 
 ; ======= Integrations ====================================

--- a/src/core/gakki/native/default.cljs
+++ b/src/core/gakki/native/default.cljs
@@ -5,6 +5,9 @@
             ["keytar" :refer [deletePassword findCredentials setPassword]]
             ["path" :as path]
             [promesa.core :as p]
+            [gakki.const :as const]
+            [gakki.util.bytesize :as bytesize]
+            [gakki.util.coll :refer [update-present]]
             [gakki.util.logging :as log]
             [gakki.util.paths :as paths]))
 
@@ -40,7 +43,13 @@
               raw (fs/readFile path)]
         (-> raw
             (js/JSON.parse)
-            (js->clj :keywordize-keys true)))
+            (js->clj :keywordize-keys true)
+
+            ; Parse typed config values
+            (update-present :cache.size (log/with-error-warn
+                                          "Invalid cache.size config:"
+                                          bytesize/parse
+                                          const/default-cache-size))))
       (p/catch (j/fn [^:js {:keys [code] :as e}]
                  (when-not (= "ENOENT" code)
                    (log/debug e))

--- a/src/core/gakki/player/cache.cljs
+++ b/src/core/gakki/player/cache.cljs
@@ -1,0 +1,34 @@
+(ns gakki.player.cache
+  "Cache management for the Player"
+  (:require [gakki.util.paths :as paths]))
+
+(defprotocol ICache
+  (size [this])
+  (on-file-created [this path])
+  (on-file-accessed [this path]))
+
+(deftype LruFsCache [cache-root max-size-bytes state]
+  ICache
+  (size [_this] max-size-bytes)
+
+  (on-file-created [_this _path]
+    (println "TODO"))
+
+  (on-file-accessed [_this _path]
+    (println "TODO")))
+
+(defn create
+  ([cache-size] (create (paths/platform :cache) cache-size))
+  ([root-path cache-size]
+   (->LruFsCache root-path cache-size (atom nil))))
+
+(defn ensure-sized
+  "Given a maybe-existing ICache object and a preferred size, return an ICache
+   instance that has the preferred size. If `existing` is non-nil and has a size
+   matching the preferred size, it is returned unchanged. Otherwise, a new ICache
+   instance is created with the given cache-size and default cache path."
+  [existing cache-size]
+  (if (and existing (= cache-size
+                       (size existing)))
+    existing
+    (create cache-size)))

--- a/src/core/gakki/player/cache.cljs
+++ b/src/core/gakki/player/cache.cljs
@@ -1,26 +1,108 @@
 (ns gakki.player.cache
   "Cache management for the Player"
-  (:require [gakki.util.paths :as paths]))
+  (:require [applied-science.js-interop :as j]
+            [clojure.string :as str]
+            ["fs/promises" :as fs]
+            [goog.structs :refer [LinkedMap]]
+            ["path" :as path]
+            [promesa.core :as p]
+            [gakki.util.logging :as log]
+            [gakki.util.paths :as paths]))
 
 (defprotocol ICache
   (size [this])
   (on-file-created [this path])
   (on-file-accessed [this path]))
 
-(deftype LruFsCache [cache-root max-size-bytes state]
+
+; ======= Cache state management ==========================
+
+(defn- create-state [max-size-bytes on-evicted]
+  (atom {:files (LinkedMap.
+                  0 ; max entries
+                  true) ; evict in insertion order ("cache mode")
+         :max-size max-size-bytes
+         :on-evicted on-evicted
+         :bytes 0}))
+
+(defn- access [{:keys [files] :as state} path]
+  (.get files path)
+  state)
+
+(defn- put-with-size
+  [{:keys [files max-size on-evicted] :as state} path size]
+  (let [contained? (.containsKey files path)]
+    (.set files path {:path path
+                      :size size})
+    (loop [state (if contained?
+                   state
+                   (update state :bytes + size))]
+      (if (<= (:bytes state) max-size)
+        ; Still within max-size
+        state
+
+        (let [evicted (.pop files)]
+          (on-evicted (:path evicted))
+          (recur (update state :bytes - (:size evicted))))))))
+
+
+; ======= FS implementation ===============================
+
+(defn initialize-state-with-stats
+  "Expects the state value (as with swap!) from (create-state) and a collection
+   of `[path #js {:size, :atimeMs}]` pairs."
+  [initial-state stats]
+  (->> stats
+       (sort-by #(j/get (second %) :atimeMs))
+       (reduce
+         (j/fn [s [path ^:js {:keys [size]}]]
+           (put-with-size s path size))
+         initial-state)))
+
+(defn- initialize-fs-cache [root-path state]
+  (log/with-timing-promise
+    :cache/init
+    (p/let [paths (fs/readdir root-path)
+            stats (->> paths
+                       (keep #(when-not (str/ends-with? % ".progress")
+                                (p/let [path (path/join root-path %)
+                                        stat (fs/stat path)]
+                                  [path stat])))
+                       p/all)]
+      ((log/of :cache) "Initializing... " root-path)
+      (swap! state initialize-state-with-stats stats))))
+
+(deftype ^:private StatePoweredPromiseSizingCache [state]
   ICache
-  (size [_this] max-size-bytes)
+  (size [_this] (:max-size @state))
 
-  (on-file-created [_this _path]
-    (println "TODO"))
+  (on-file-created [_this path]
+    (-> (p/let [stat (fs/stat path)]
+          (swap! state put-with-size path (j/get stat :size)))
+        (p/catch (partial
+                   log/error
+                   "Unable to update cache for download of" path))))
 
-  (on-file-accessed [_this _path]
-    (println "TODO")))
+  (on-file-accessed [_this path]
+    (swap! state access path)))
+
+(defn- ^ICache create-fs-with-state [state]
+  (->StatePoweredPromiseSizingCache state))
+
+(defn- on-evict-file [path]
+  ((log/of :cache) "Evicting" path "...")
+  (println "TODO evict" path))
+
+; ======= Public interface ================================
 
 (defn create
   ([cache-size] (create (paths/platform :cache) cache-size))
   ([root-path cache-size]
-   (->LruFsCache root-path cache-size (atom nil))))
+   (let [state (create-state
+                 cache-size
+                 on-evict-file)]
+     (initialize-fs-cache root-path state)
+     (create-fs-with-state state))))
 
 (defn ensure-sized
   "Given a maybe-existing ICache object and a preferred size, return an ICache
@@ -32,3 +114,16 @@
                        (size existing)))
     existing
     (create cache-size)))
+
+
+#_:clj-kondo/ignore
+(comment
+
+  (-> (paths/platform :cache)
+      (initialize-fs-cache (create-state
+                             (* 1024 1024 1024)
+                             on-evict-file))
+      (p/then cljs.pprint/pprint)
+      (p/catch log/error))
+
+  )

--- a/src/core/gakki/player/pcm.cljs
+++ b/src/core/gakki/player/pcm.cljs
@@ -1,5 +1,6 @@
 (ns gakki.player.pcm
-  (:require ["path" :as path]
+  (:require [archetype.util :refer [>evt]]
+            ["path" :as path]
             [promesa.core :as p]
             [gakki.util.loading :refer [with-loading-promise]]
             [gakki.util.logging :as log]
@@ -23,6 +24,10 @@
               ; read-config to ensure it's not only *there* but *valid*
               (pcm/read-config source)
               (log/player "opening cached @" destination-path)
+
+              ; The file seems fine; let's mark it as accessed for cache
+              ; management purposes
+              (>evt [:cache/file-accessed destination-path])
               source))
 
           (p/catch

--- a/src/core/gakki/player/pcm/caching.cljs
+++ b/src/core/gakki/player/pcm/caching.cljs
@@ -3,6 +3,7 @@
    from *somewhere* and caches them to a file on disk, providing seekable
    access to however much of the input stream has been written."
   (:require [applied-science.js-interop :as j]
+            [archetype.util :refer [>evt]]
             [clojure.string :as str]
             ["fs" :rename {createWriteStream create-write-stream
                            createReadStream create-read-stream}]
@@ -210,6 +211,7 @@
                    (log/debug "Completed download of " destination-path)
                    (-> (complete-download tmp-path destination-path)
                        (p/then (fn []
+                                 (>evt [:cache/download-completed])
                                  (swap! state assoc
                                         :disk (disk/create destination-path))))))))
 

--- a/src/core/gakki/player/pcm/caching.cljs
+++ b/src/core/gakki/player/pcm/caching.cljs
@@ -211,7 +211,7 @@
                    (log/debug "Completed download of " destination-path)
                    (-> (complete-download tmp-path destination-path)
                        (p/then (fn []
-                                 (>evt [:cache/download-completed])
+                                 (>evt [:cache/download-completed destination-path])
                                  (swap! state assoc
                                         :disk (disk/create destination-path))))))))
 

--- a/src/core/gakki/subs.cljs
+++ b/src/core/gakki/subs.cljs
@@ -1,5 +1,6 @@
 (ns gakki.subs
   (:require [re-frame.core :refer [reg-sub]]
+            [gakki.db :as db]
             [gakki.const :as const :refer [max-volume-int]]
             [gakki.util.media :refer [category-id]]))
 
@@ -8,6 +9,7 @@
 (reg-sub :artists :artist)
 (reg-sub :playlists :playlist)
 (reg-sub ::carousel-data ::carousel-data)
+(reg-sub ::prefs :prefs)
 
 (reg-sub
   :loading?
@@ -34,6 +36,19 @@
   :<- [:accounts]
   (fn [accounts [_ provider-id]]
     (get accounts provider-id)))
+
+
+; ======= prefs ===========================================
+
+(reg-sub
+  :prefs
+  :<- [::prefs]
+  (fn [prefs [_ ?pref]]
+    (if ?pref
+      (if-some [pref (get prefs ?pref)]
+        pref
+        (get db/default-prefs ?pref))
+      prefs)))
 
 
 ; ======= player ==========================================

--- a/src/core/gakki/util/bytesize.cljs
+++ b/src/core/gakki/util/bytesize.cljs
@@ -1,0 +1,27 @@
+(ns gakki.util.bytesize
+  (:require [clojure.string :as str]))
+
+(def ^:private byte-size-pattern #"([0-9,.]+)\s*([kmgt])")
+(def ^:private unit-scale
+  {"k" 10
+   "m" 20
+   "g" 30
+   "t" 40})
+
+(defn parse
+  ([s default] (try (parse s)
+                    (catch :default _
+                      default)))
+  ([s]
+   (if (number? s)
+     ; Simple case: pass through numbers unchanged
+     s
+
+     (if-let [[_ raw-number unit] (->> (str/replace s #"[,.]" "")
+                                       (str/lower-case)
+                                       (re-find byte-size-pattern))]
+       (let [number (js/parseInt raw-number 10)
+             scale (get unit-scale unit 1)]
+         (* number (js/Math.pow 2 scale)))
+
+       (throw (ex-info "Invalid byte-size description" {:input s}))))))

--- a/src/core/gakki/util/coll.cljs
+++ b/src/core/gakki/util/coll.cljs
@@ -19,6 +19,20 @@
   (when (< n (count coll))
     (nth coll n)))
 
+(defn update-present
+  "Like `update` but is a no-op (IE: returns `m` unchanged) if the key does not
+   exist in the map"
+  ([m k f]
+   (if-not (contains? m k) m (update m k f)))
+  ([m k f x]
+   (if-not (contains? m k) m (update m k f x)))
+  ([m k f x y]
+   (if-not (contains? m k) m (update m k f x y)))
+  ([m k f x y z]
+   (if-not (contains? m k) m (update m k f x y z)))
+  ([m k f x y z & more]
+   (if-not (contains? m k) m (apply update m k f x y z more))))
+
 (defn vec-dissoc [coll v]
   (cond
     ; Special optimizations for last...

--- a/src/core/gakki/util/logging.cljs
+++ b/src/core/gakki/util/logging.cljs
@@ -74,6 +74,20 @@
     (when-let [stack (when ex (.-stack ex))]
       (println (chalk/gray stack)))))
 
+(defn with-error-warn
+  "Wraps a function f with a new function that caches errors thrown by `f` and
+   logs them, returning `fallback-value`. Logs may optionally be prefixed"
+  ([f fallback-value] (with-error-warn "" f fallback-value))
+  ([log-prefix f fallback-value]
+   (fn wrap-error [& args]
+     (try
+       (apply f args)
+       (catch :default e
+         ; NOTE: We probably don't need the stack trace, so just show the
+         ; message and any data attached:
+         (error log-prefix (ex-message e) (ex-data e))
+         fallback-value)))))
+
 
 ; ======= Timing ==========================================
 

--- a/src/test/gakki/player/cache_test.cljs
+++ b/src/test/gakki/player/cache_test.cljs
@@ -1,0 +1,41 @@
+(ns gakki.player.cache-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [gakki.player.cache :as cache]))
+
+(deftest cache-state-test
+  (testing "LRU eviction"
+    (let [evicted (atom [])
+          c (#'cache/create-state
+              5 (partial swap! evicted conj))]
+      (swap! c #'cache/put-with-size "four" 4)
+      (swap! c #'cache/put-with-size "one" 1)
+      (swap! c #'cache/put-with-size "four" 4)
+      (is (empty? @evicted))
+
+      (swap! c #'cache/put-with-size "new" 1)
+      (is (= ["one"] @evicted))
+
+      (swap! c #'cache/put-with-size "newest" 5)
+      (is (= ["one" "four" "new"] @evicted)))))
+
+(deftest state-init-test
+  (testing "Initialize state"
+    (let [evicted (atom [])
+          c (#'cache/create-state
+              5 (partial swap! evicted conj))]
+      (swap! c cache/initialize-state-with-stats
+             [["old" #js {:size 1 :atimeMs 1}]
+              ["newest" #js {:size 1 :atimeMs 5}]
+              ["oldest" #js {:size 1 :atimeMs 0}]
+              ["newer" #js {:size 1 :atimeMs 3}]
+              ["new" #js {:size 1 :atimeMs 2}]])
+      (is (empty? @evicted))
+
+      (swap! c #'cache/put-with-size "evict-oldest" 1)
+      (is (= ["oldest"] @evicted))
+
+      (swap! c #'cache/put-with-size "evict-old" 1)
+      (is (= ["oldest" "old"] @evicted))
+
+      (swap! c #'cache/put-with-size "evict-new" 1)
+      (is (= ["oldest" "old" "new"] @evicted)))))

--- a/src/test/gakki/util/bytesize_test.cljs
+++ b/src/test/gakki/util/bytesize_test.cljs
@@ -1,0 +1,31 @@
+(ns gakki.util.bytesize-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [gakki.util.bytesize :refer [parse]]))
+
+(deftest parse-test
+  (testing "Detect unit correctly"
+    (is (= 1024 (parse "1KB")))
+    (is (= (* 1024 1024) (parse "1Mb")))
+    (is (= (* 1024 1024 1024) (parse "1gb")))
+    (is (= (* 1024 1024 1024 1024) (parse "1tB"))))
+
+  (testing "Pass through integers unchanged"
+    (is (= 1024 (parse 1024))))
+
+  (testing "Larger numbers"
+    (is (= (* 1024 1000) (parse "1000kb")))
+    (is (= (* 1024 1000) (parse "1,000kb"))))
+
+  (testing "No negative numbers"
+    (is (= (* 1024 1000) (parse "-1000kb"))))
+
+  (testing "No fractional support; separators are ignored to be locale-agnostic"
+    (is (= (* 1024 1024 1024 5) (parse ".5g")))
+    (is (= (* 1024 1024 1024 5000) (parse "5.000g"))))
+
+  (testing "Catch invalid input with default"
+    (is (= 42 (parse "g" 42)))
+    (is (= 42 (parse "1" 42)))
+    (is (= 42 (parse "" 42)))))
+
+


### PR DESCRIPTION
Cache size defaults to 1gb. Cache size can be adjusted via `~/.config/gakki/prefs.json` via the `cache.size` key. For example:

```js
{
  "cache.size": "1g"
}
```

This preference understands the suffix "m" for megabytes, "g" for gigabytes, and "t" for terabytes. It ignores commas and periods, so `1.000g` is equivalent to `1,000g` and to `1000g`, to avoid confusion with different locales. This means instead of writing `0.5g` for "half a gigabyte," you should just do `500m`.

- Add initial support for configuring cache size
- Scaffold out cache management
- Scaffold initial cache handling
- Wire up cache management and fix LinkedMap import
