### PR TITLE
Add rough, initial radio/shuffle playlist support

### DIFF
--- a/src/cli/gakki/views.cljs
+++ b/src/cli/gakki/views.cljs
@@ -13,6 +13,7 @@
             [gakki.views.home :as home]
             [gakki.views.playlist :as playlist]
             [gakki.views.queue :as queue]
+            [gakki.views.radio :as radio]
             [gakki.views.search :as search]
             [gakki.views.search-results :as search-results]
             [gakki.views.splash :as splash]))
@@ -25,6 +26,7 @@
    :artist #'artist/view
    :help #'help/view
    :playlist #'playlist/view
+   :radio #'radio/view
    :queue #'queue/view
    :search #'search/view
    :search/results #'search-results/view

--- a/src/cli/gakki/views/artist.cljs
+++ b/src/cli/gakki/views/artist.cljs
@@ -1,5 +1,5 @@
 (ns gakki.views.artist
-  (:require [archetype.util :refer [<sub]]
+  (:require [archetype.util :refer [>evt <sub]]
             ["ink" :as k]
             [gakki.cli.input :refer [use-input]]
             [gakki.components.carousels :refer [carousels]]
@@ -7,9 +7,16 @@
             [gakki.components.frame :refer [frame]]
             [gakki.theme :as theme]))
 
+(def ^:private help
+  {"S" "Shuffle Artist"
+
+   :header "Artist Page"})
+
 (defn view [artist-id]
   (let [artist (<sub [:artist artist-id])]
-    (use-input {:help {:header "Artist Page"}})
+    (use-input {"s" #(when-let [playlist (:shuffle artist)]
+                       (>evt [:player/open playlist]))
+                :help help})
 
     [frame
      [header

--- a/src/cli/gakki/views/artist.cljs
+++ b/src/cli/gakki/views/artist.cljs
@@ -8,13 +8,16 @@
             [gakki.theme :as theme]))
 
 (def ^:private help
-  {"S" "Shuffle Artist"
+  {"S" "Open a Shuffle playlist for this Artist"
+   "R" "Open a Radio for this Artist"
 
    :header "Artist Page"})
 
 (defn view [artist-id]
   (let [artist (<sub [:artist artist-id])]
-    (use-input {"s" #(when-let [playlist (:shuffle artist)]
+    (use-input {"S" #(when-let [playlist (:shuffle artist)]
+                       (>evt [:player/open playlist]))
+                "R" #(when-let [playlist (:radio artist)]
                        (>evt [:player/open playlist]))
                 :help help})
 

--- a/src/cli/gakki/views/radio.cljs
+++ b/src/cli/gakki/views/radio.cljs
@@ -1,0 +1,24 @@
+(ns gakki.views.radio
+  (:require [archetype.util :refer [>evt <sub]]
+            ["ink" :as k]
+            [gakki.cli.input :refer [use-input]]
+            [gakki.components.header :refer [header]]
+            [gakki.theme :as theme]
+            [gakki.views.queue :refer [track-list]]))
+
+(defn radio-header [radio]
+  [header {:padding-bottom 1}
+   [:> k/Text {:color theme/text-color-disabled}
+    "Radio / "]
+   (:title radio)])
+
+(defn view [id]
+  (use-input {:help {:header "Radio"}})
+  (let [radio (<sub [:radio id])]
+    [:f> track-list
+     :items (<sub [:radio/items-with-state id])
+     :header [radio-header radio]
+     :on-whole-list-selected #(>evt [:player/play-items (:items radio)])
+     :on-index-selected #(>evt [:player/play-items (:items radio) %])]))
+
+

--- a/src/core/gakki/accounts/core.cljs
+++ b/src/core/gakki/accounts/core.cljs
@@ -32,6 +32,10 @@
     [this account playlist-id]
     "Return a promise...")
 
+  (resolve-radio
+    [this account radio]
+    "Return a promise...")
+
   (search
     [this account query])
 

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -143,13 +143,14 @@
                    "VLPLw6X_oq5Z8kl_Myg9QL1ZKxV1BobTeXrb") ]
     (cljs.pprint/pprint result))
 
-  ; this is a "shuffle CHVRCHES" playlist ID:
-  (p/let [result (do-resolve-radio
-                   (:ytm @(re-frame.core/subscribe [:accounts]))
-                   {:id "80QNzlx-Fyg"
-                    :playlist-id "RDAOoxcn6rFh4zxhtR0lDvIPBA"
-                    :radio/kind :track})]
-    (cljs.pprint/pprint result))
+  ; this is a "shuffle CHVRCHES" radio
+  (-> (p/let [result (do-resolve-radio
+                       (:ytm @(re-frame.core/subscribe [:accounts]))
+                       {:id "80QNzlx-Fyg"
+                        :playlist-id "RDAOoxcn6rFh4zxhtR0lDvIPBA"
+                        :radio/kind :track})]
+        (cljs.pprint/pprint result))
+      (p/catch log/error))
 
   (p/let [result (do-resolve-album
                    (:ytm @(re-frame.core/subscribe [:accounts]))

--- a/src/core/gakki/accounts/ytm/artist.cljs
+++ b/src/core/gakki/accounts/ytm/artist.cljs
@@ -10,15 +10,14 @@
             [gakki.const :as const]))
 
 (defn- unpack-playlist [header button-key title]
-  (when-let [radio-id (-> header
-                          (j/get-in [button-key
-                                     :buttonRenderer])
-                          unpack-navigation-endpoint
-                          :id)]
-    {:id radio-id
-     :kind :playlist
-     :provider :ytm
-     :title title}))
+  (when-let [radio (-> header
+                       (j/get-in [button-key
+                                  :buttonRenderer])
+                       unpack-navigation-endpoint)]
+    (assoc radio
+           :radio/kind (:kind radio)
+           :kind :radio
+           :title title)))
 
 (defn load [^YTMusic client id]
   (p/let [response (send-request (.-cookie client)

--- a/src/core/gakki/accounts/ytm/artist.cljs
+++ b/src/core/gakki/accounts/ytm/artist.cljs
@@ -18,7 +18,7 @@
     {:id radio-id
      :kind :playlist
      :provider :ytm
-     :title (str title " Radio")}))
+     :title title}))
 
 (defn load [^YTMusic client id]
   (p/let [response (send-request (.-cookie client)
@@ -50,6 +50,6 @@
      :description (-> header
                       (j/get :description)
                       (runs->text))
-     :radio (unpack-playlist header :startRadioButton (str "Shuffle " title))
-     :shuffle (unpack-playlist header :playButton (str title " Radio"))
+     :radio (unpack-playlist header :startRadioButton (str title " Radio"))
+     :shuffle (unpack-playlist header :playButton (str "Shuffle " title))
      :categories (keep music-shelf->section raw-rows)}))

--- a/src/core/gakki/accounts/ytm/music_shelf.cljs
+++ b/src/core/gakki/accounts/ytm/music_shelf.cljs
@@ -1,6 +1,5 @@
 (ns gakki.accounts.ytm.music-shelf
   (:require [applied-science.js-interop :as j]
-            [clojure.string :as str]
             [gakki.accounts.ytm.util :as util :refer [->seconds
                                                       runs->text
                                                       unpack-navigation-endpoint]]
@@ -28,7 +27,7 @@
     (let [[artist album duration] (-> items
                                       second
                                       :title
-                                      (str/split #"  •  "))]
+                                      util/split-string-by-dots)]
       (assoc (first items)
              :artist artist
              :album album

--- a/src/core/gakki/accounts/ytm/upnext.cljs
+++ b/src/core/gakki/accounts/ytm/upnext.cljs
@@ -1,14 +1,63 @@
 (ns gakki.accounts.ytm.upnext
   (:require [applied-science.js-interop :as j]
+            [gakki.accounts.ytm.util :as util :refer [runs->text]]
             [promesa.core :as p]
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request
                                                generateBody generate-body}]))
 
+(defmulti parse-item (fn [container] (first (js/Object.keys container))))
+
+(defmethod parse-item "playlistPanelVideoRenderer"
+  [^js container]
+  (j/let [^:js {renderer :playlistPanelVideoRenderer} container]
+    {:id (j/get renderer :videoId)
+     :kind :track
+     :provider :ytm
+     :image-url (util/pick-thumbnail renderer)
+     :duration (some-> (j/get renderer :lengthText)
+                       runs->text
+                       util/->seconds)
+     :album (-> (j/get renderer :longBylineText)
+                util/split-runs-by-dots
+                second)
+     :artist (runs->text (j/get renderer :shortBylineText))
+     :title (runs->text (j/get renderer :title))}))
+
+(defn- parse-items [^js response]
+  (let [raw-root (j/get-in response [:contents
+                                     :singleColumnMusicWatchNextResultsRenderer
+                                     :tabbedRenderer
+                                     :watchNextTabbedResultsRenderer
+                                     :tabs
+                                     0
+                                     :tabRenderer
+                                     :content
+                                     :musicQueueRenderer
+                                     :content
+                                     :playlistPanelRenderer])
+        continuations (j/get raw-root :continuations)]
+    {:items (->> (j/get raw-root :contents)
+                 (map parse-item))
+     :continuations continuations}))
+
+(defn inflate [base, ^js response]
+  (merge base
+         {:provider :ytm
+          :kind :radio}
+         (parse-items response)))
+
 (defn load [^YTMusic client info]
-  (p/let [body (-> (generate-body #js {})
-                   (j/assoc! :playlistId (:playlist-id info)))
+  (p/let [body (cond-> (generate-body #js {})
+                 (:playlist-id info)
+                 (j/assoc! :playlistId (:playlist-id info))
+
+                 (= :track (:radio/kind info))
+                 (j/assoc! :videoId (:id info))
+
+                 (:params info)
+                 (j/assoc! :params (:params info)))
           response (send-request (.-cookie client)
                                  (j/lit
                                    {:endpoint "next"
                                     :body body}))]
-    response))
+    (inflate info response)))

--- a/src/core/gakki/accounts/ytm/upnext.cljs
+++ b/src/core/gakki/accounts/ytm/upnext.cljs
@@ -1,0 +1,14 @@
+(ns gakki.accounts.ytm.upnext
+  (:require [applied-science.js-interop :as j]
+            [promesa.core :as p]
+            ["ytmusic/dist/lib/utils" :rename {sendRequest send-request
+                                               generateBody generate-body}]))
+
+(defn load [^YTMusic client info]
+  (p/let [body (-> (generate-body #js {})
+                   (j/assoc! :playlistId (:playlist-id info)))
+          response (send-request (.-cookie client)
+                                 (j/lit
+                                   {:endpoint "next"
+                                    :body body}))]
+    response))

--- a/src/core/gakki/accounts/ytm/upnext.cljs
+++ b/src/core/gakki/accounts/ytm/upnext.cljs
@@ -1,6 +1,7 @@
 (ns gakki.accounts.ytm.upnext
   (:require [applied-science.js-interop :as j]
             [gakki.accounts.ytm.util :as util :refer [runs->text]]
+            [gakki.util.logging :refer [with-timing-promise]]
             [promesa.core :as p]
             ["ytmusic/dist/lib/utils" :rename {sendRequest send-request
                                                generateBody generate-body}]))
@@ -56,8 +57,9 @@
 
                  (:params info)
                  (j/assoc! :params (:params info)))
-          response (send-request (.-cookie client)
-                                 (j/lit
-                                   {:endpoint "next"
-                                    :body body}))]
+          response (->> (send-request (.-cookie client)
+                                      (j/lit
+                                        {:endpoint "next"
+                                         :body body}))
+                        (with-timing-promise :ytm/upnext-load))]
     (inflate info response)))

--- a/src/core/gakki/accounts/ytm/util.cljs
+++ b/src/core/gakki/accounts/ytm/util.cljs
@@ -58,17 +58,23 @@
   (let [endpoint (or (j/get runs-container-or-endpoint :navigationEndpoint)
                      (j/get-in runs-container-or-endpoint [:runs 0 :navigationEndpoint]))
         playlist-id (j/get-in endpoint [:watchPlaylistEndpoint :playlistId])
-        watch-id (or (j/get-in endpoint [:watchEndpoint :videoId])
-                     playlist-id)]
-    {:id (or watch-id
-             (j/get-in endpoint [:browseEndpoint :browseId]))
-     :provider :ytm
-     :kind (let [raw-kind (j/get-in endpoint [:browseEndpoint
-                                              :browseEndpointContextSupportedConfigs
-                                              :browseEndpointContextMusicConfig
-                                              :pageType])]
-             (get ytm-kinds raw-kind (cond
-                                       playlist-id :playlist
-                                       watch-id :track
-                                       :else :unknown)))}))
+        watch-id (j/get-in endpoint [:watchEndpoint :videoId])
+        id (or watch-id
+               playlist-id
+               (j/get-in endpoint [:browseEndpoint :browseId]))]
+    (when id
+      {:id id
+       :playlist-id (or playlist-id
+                        (j/get-in endpoint [:watchEndpoint :playlistId]))
+       :params (or (j/get-in endpoint [:watchEndpoint :params])
+                   (j/get-in endpoint [:watchPlaylistEndpoint :params]))
+       :provider :ytm
+       :kind (let [raw-kind (j/get-in endpoint [:browseEndpoint
+                                                :browseEndpointContextSupportedConfigs
+                                                :browseEndpointContextMusicConfig
+                                                :pageType])]
+               (get ytm-kinds raw-kind (cond
+                                         playlist-id :playlist
+                                         watch-id :track
+                                         :else :unknown)))})))
 

--- a/src/core/gakki/accounts/ytm/util.cljs
+++ b/src/core/gakki/accounts/ytm/util.cljs
@@ -54,6 +54,13 @@
       (when-let [child (single-key-child container)]
         (recur child)))))
 
+(defn split-string-by-dots [s]
+  (str/split s #"  •  "))
+
+(defn split-runs-by-dots [runs]
+  (-> (runs->text runs)
+      (split-string-by-dots)))
+
 (defn unpack-navigation-endpoint [^js runs-container-or-endpoint]
   (let [endpoint (or (j/get runs-container-or-endpoint :navigationEndpoint)
                      (j/get-in runs-container-or-endpoint [:runs 0 :navigationEndpoint]))

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -210,21 +210,16 @@
   :player/open
   [trim-v]
   (fn [{:keys [db]} [item]]
-    (let [item (inflate-item db item)]
-      (case (:kind item)
+    (let [{:keys [kind] :as item} (inflate-item db item)]
+      (case kind
         :track {:dispatch [::set-current-playable item]}
 
-        :playlist (if (seq (:items item))
-                    {:dispatch [:navigate! [:playlist (:id item)]]}
+        (:album :playlist :radio)
+        (if (seq (:items item))
+          {:dispatch [:navigate! [kind (:id item)]]}
 
-                    ; Unresolved playlist; fetch and resolve now:
-                    {:providers/resolve-and-open [:playlist (:accounts db) item]})
-
-        :album (if (seq (:items item))
-                 {:dispatch [:navigate! [:album (:id item)]]}
-
-                 ; Unresolved album; fetch and resolve now:
-                 {:providers/resolve-and-open [:album (:accounts db) item]})
+          ; Unresolved; fetch and resolve now:
+          {:providers/resolve-and-open [kind (:accounts db) item]})
 
         :artist (if (:categories item)
                   {:dispatch [:navigate! [:artist (:id item)]]}

--- a/src/core/gakki/fx.cljs
+++ b/src/core/gakki/fx.cljs
@@ -129,10 +129,11 @@
         (-> (p/let [f (case kind
                         :album ap/resolve-album
                         :artist ap/resolve-artist
-                        :playlist ap/resolve-playlist)
+                        :playlist ap/resolve-playlist
+                        :radio ap/resolve-radio)
                     result (f provider
                               account
-                              (:id entity))]
+                              entity)]
               (if (or (seq (:items result))
                       (seq (:categories result)))
                 (>evt [:player/on-resolved kind result :action/open])


### PR DESCRIPTION
We currently only support this for artists, and only *from* artist pages, although in theory we ought to be able to extract this information from carousels like the home page, as well. We also don't yet paginate through the radio at all, but we do have the continuation data if we decide to sit down and figure out what to do with it!

- Fix naming of artist shuffle/radio playlists
- Refactor resolve methods to take full object; scaffold radio fetch
- Add radio view, and support opening it
- Support opening artist radio, as well

<img width="801" alt="Screen Shot 2021-07-31 at 9 44 19 AM" src="https://user-images.githubusercontent.com/816150/127741836-77815cf6-f189-4d04-b394-380ae456c035.png">
