### PR TITLE
Support paginating playlists/radios

### DIFF
--- a/src/cli/gakki/views/playlist.cljs
+++ b/src/cli/gakki/views/playlist.cljs
@@ -18,5 +18,5 @@
     [:f> track-list
      :items (<sub [:playlist/items-with-state id])
      :header [playlist-header playlist]
-     :on-whole-list-selected #(>evt [:player/play-items (:items playlist)])
-     :on-index-selected #(>evt [:player/play-items (:items playlist) %])]))
+     :on-whole-list-selected #(>evt [:player/play-items playlist])
+     :on-index-selected #(>evt [:player/play-items playlist %])]))

--- a/src/cli/gakki/views/radio.cljs
+++ b/src/cli/gakki/views/radio.cljs
@@ -18,7 +18,7 @@
     [:f> track-list
      :items (<sub [:radio/items-with-state id])
      :header [radio-header radio]
-     :on-whole-list-selected #(>evt [:player/play-items (:items radio)])
-     :on-index-selected #(>evt [:player/play-items (:items radio) %])]))
+     :on-whole-list-selected #(>evt [:player/play-items radio])
+     :on-index-selected #(>evt [:player/play-items radio %])]))
 
 

--- a/src/core/gakki/accounts/core.cljs
+++ b/src/core/gakki/accounts/core.cljs
@@ -22,10 +22,10 @@
 
   (paginate
     [this account entity index]
-    "Return a promise resolving to a map containing the next `:items`
-     in the passed entity. Any other keys in the resolved map will be
-     merged into the original entity (for updating pagination data,
-     for example).
+    "Return a promise resolving to a map containing an updated :entity and the
+     :next-items in the passed entity. Any other keys in the resolved map will
+     be merged into the original entity (for updating pagination data, for
+     example).
 
      If the entity cannot paginate, this method should return nil.")
 

--- a/src/core/gakki/accounts/core.cljs
+++ b/src/core/gakki/accounts/core.cljs
@@ -20,6 +20,15 @@
       [{:name \"Category Name\"
         :items []}]}")
 
+  (paginate
+    [this account entity]
+    "Return a promise resolving to a map containing the next `:items`
+     in the passed entity. Any other keys in the resolved map will be
+     merged into the original entity (for updating pagination data,
+     for example).
+
+     If the entity cannot paginate, this method should return nil.")
+
   (resolve-album
     [this account album-id]
     "Return a promise...")

--- a/src/core/gakki/accounts/core.cljs
+++ b/src/core/gakki/accounts/core.cljs
@@ -21,7 +21,7 @@
         :items []}]}")
 
   (paginate
-    [this account entity]
+    [this account entity index]
     "Return a promise resolving to a map containing the next `:items`
      in the passed entity. Any other keys in the resolved map will be
      merged into the original entity (for updating pagination data,

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -86,7 +86,7 @@
       {:entity (-> entity
                    (update :items into (:items up-next))
                    (assoc :continuations (:continuations up-next)))
-       :new-items (:items up-next)})))
+       :next-items (:items up-next)})))
 
 (defn- do-resolve-playlist [account playlist-id]
   (p/let [^YTMusic ytm (account->client account)]

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -63,6 +63,13 @@
                    {:title title
                     :items (map ->home-item content)})))})))
 
+(defn- do-paginate [account entity]
+  ((log/of :ytm) "TODO: paginate" (:continuation entity))
+  (when false
+    (p/let [^YTMusic _ytm (account->client account)]
+      ; TODO paginate
+      nil)))
+
 (defn- do-resolve-playlist [account playlist-id]
   (p/let [^YTMusic ytm (account->client account)]
     ; TODO lazily continue loading the playlist? We can use:
@@ -97,6 +104,9 @@
   (fetch-home [_ account]
     ; NOTE: this is pulled out to a separate fn to facilitate hot-reload dev
     (do-fetch-home account))
+
+  (paginate [_ account entity]
+    (do-paginate account entity))
 
   (resolve-album [_ account {album-id :id}]
     (do-resolve-album account album-id))

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -64,7 +64,7 @@
                     :items (map ->home-item content)})))})))
 
 (defn- do-paginate [account entity]
-  ((log/of :ytm) "TODO: paginate" (:continuation entity))
+  ((log/of :ytm) "TODO: paginate" (:continuations entity))
   (when false
     (p/let [^YTMusic _ytm (account->client account)]
       ; TODO paginate

--- a/src/core/gakki/accounts/ytm.cljs
+++ b/src/core/gakki/accounts/ytm.cljs
@@ -83,12 +83,10 @@
                                                        :clickTrackingParams])
                              :index index))]
 
-      ; TODO paginate
-      ((log/of :ytm) "Loaded: " up-next)
-
-      (-> entity
-          (update :items into (:items up-next))
-          (assoc :continuations (:continuations up-next))))))
+      {:entity (-> entity
+                   (update :items into (:items up-next))
+                   (assoc :continuations (:continuations up-next)))
+       :new-items (:items up-next)})))
 
 (defn- do-resolve-playlist [account playlist-id]
   (p/let [^YTMusic ytm (account->client account)]

--- a/src/core/gakki/events.cljs
+++ b/src/core/gakki/events.cljs
@@ -48,7 +48,8 @@
                       (fnil conj [])
                       [:dedup-promised-fx [:providers/paginate!
                                            {:accounts (:accounts db)
-                                            :entity entity}]])))))))
+                                            :entity entity
+                                            :index index}]])))))))
 
 
 ; ======= Core events =====================================

--- a/src/core/gakki/fx.cljs
+++ b/src/core/gakki/fx.cljs
@@ -140,12 +140,12 @@
 
 (reg-fx
   :providers/paginate!
-  (fn [{:keys [accounts] {k :provider :keys [kind] :as entity} :entity}]
+  (fn [{:keys [accounts index] {k :provider :keys [kind] :as entity} :entity}]
     (let [provider (get providers k)
           account (get accounts k)]
 
       (if (and provider account)
-        (when-let [p (ap/paginate provider account entity)]
+        (when-let [p (ap/paginate provider account entity index)]
           (-> (p/let [result p]
                 (if (seq (:items result))
                   ((log/of :providers/paginate!) "TODO: handle: " result)

--- a/src/core/gakki/fx.cljs
+++ b/src/core/gakki/fx.cljs
@@ -154,7 +154,7 @@
                     (>evt [:player/on-resolved kind new-entity :action/queue-entity])
                     (>evt [:player/enqueue-items next-items]))
 
-                  (log/error "Empty " kind " from " k " = " result)))
+                  (log/error "Empty " kind " from paginating " k " = " result)))
 
               (with-loading-promise :providers/paginate!)
 


### PR DESCRIPTION
We will now load in subsequent pages of a radio or playlist that support it when your playback nears the end!

- Scaffold out basic support for playlist pagination
- Unify pagination check logic using an interceptor
- Load continuations for YTM
- Write new entities for the queue into the re-frame db!
- Fix: returning items as `:new-items` instead of `:next-items`
