### PR TITLE
Monitor audio devices on macOS and update playback config in response

### DIFF
--- a/macos/gakki/gakki.xcodeproj/project.pbxproj
+++ b/macos/gakki/gakki.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		653F75C927DA855F00F5ADD6 /* AudioDeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653F75C827DA855F00F5ADD6 /* AudioDeviceManager.swift */; };
+		653F75CB27DA856A00F5ADD6 /* AudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653F75CA27DA856A00F5ADD6 /* AudioDevice.swift */; };
 		6565346C267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6565346B267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift */; };
 		65C58C7F265862B2001C4796 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C58C7E265862B1001C4796 /* Command.swift */; };
 		65C58C812658652F001C4796 /* convertFromKebabCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C58C802658652F001C4796 /* convertFromKebabCase.swift */; };
@@ -40,6 +42,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		653F75C827DA855F00F5ADD6 /* AudioDeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDeviceManager.swift; sourceTree = "<group>"; };
+		653F75CA27DA856A00F5ADD6 /* AudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDevice.swift; sourceTree = "<group>"; };
 		6565346B267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MPNowPlayingInfoCenter+Extensions.swift"; sourceTree = "<group>"; };
 		65C58C7E265862B1001C4796 /* Command.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		65C58C802658652F001C4796 /* convertFromKebabCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = convertFromKebabCase.swift; sourceTree = "<group>"; };
@@ -87,6 +91,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		653F75C727DA854800F5ADD6 /* Devices */ = {
+			isa = PBXGroup;
+			children = (
+				653F75C827DA855F00F5ADD6 /* AudioDeviceManager.swift */,
+				653F75CA27DA856A00F5ADD6 /* AudioDevice.swift */,
+			);
+			path = Devices;
+			sourceTree = "<group>";
+		};
 		6565346A267A442600679CA5 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -134,6 +147,7 @@
 		65F36FB52653E89B0062940F /* gakki */ = {
 			isa = PBXGroup;
 			children = (
+				653F75C727DA854800F5ADD6 /* Devices */,
 				B6B19AC2265ABF88008635AC /* Commands */,
 				6565346A267A442600679CA5 /* Extensions */,
 				65C58C85265868B7001C4796 /* Model */,
@@ -315,6 +329,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				653F75CB27DA856A00F5ADD6 /* AudioDevice.swift in Sources */,
 				65F36FB92653E89B0062940F /* ContentView.swift in Sources */,
 				65C58C84265868AE001C4796 /* CommandHandler.swift in Sources */,
 				65F36FB72653E89B0062940F /* AppDelegate.swift in Sources */,
@@ -323,6 +338,7 @@
 				65C58C8726586B0C001C4796 /* IPC.swift in Sources */,
 				65C58C812658652F001C4796 /* convertFromKebabCase.swift in Sources */,
 				6565346C267A442600679CA5 /* MPNowPlayingInfoCenter+Extensions.swift in Sources */,
+				653F75C927DA855F00F5ADD6 /* AudioDeviceManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macos/gakki/gakki/AppDelegate.swift
+++ b/macos/gakki/gakki/AppDelegate.swift
@@ -16,6 +16,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     var popover: NSPopover!
     var statusBarItem: NSStatusItem!
+    var audioDeviceManager: AudioDeviceManager!
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         if CommandLine.arguments.contains("--show-ui") {
@@ -34,7 +35,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         }
 
-        attachHandlers()
+        self.audioDeviceManager = AudioDeviceManager()
+        self.audioDeviceManager.listen()
+        attachMediaCommandHandlers()
         MPNowPlayingInfoCenter.default().playbackState = .playing
         MPNowPlayingInfoCenter.default().playbackState = .paused
 
@@ -46,7 +49,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
-        // Insert code here to tear down your application
+        self.audioDeviceManager.unlisten()
     }
 
     @objc func togglePopover(_ sender: AnyObject?) {
@@ -59,7 +62,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    private func attachHandlers() {
+    private func attachMediaCommandHandlers() {
         let commandCenter = MPRemoteCommandCenter.shared()
         let playPause = commandCenter.togglePlayPauseCommand
         playPause.isEnabled = true

--- a/macos/gakki/gakki/Devices/AudioDevice.swift
+++ b/macos/gakki/gakki/Devices/AudioDevice.swift
@@ -1,0 +1,133 @@
+//
+//  AudioDevice.swift
+//  gakki
+//
+//  Created by Daniel Leong on 3/10/22.
+//
+
+import CoreAudio
+import Foundation
+
+class AudioDevice {
+    private var id: AudioDeviceID
+    private var listening = false
+
+    var nominalSampleRate: Float64? {
+        guard let address = validAddress(selector: kAudioDevicePropertyNominalSampleRate) else {
+            return nil
+        }
+        return getProperty(address: address, defaultValue: 0.0)
+    }
+
+    init(withID id: AudioDeviceID) {
+        self.id = id
+    }
+
+    deinit {
+        unlisten()
+    }
+
+    func listen() {
+        if listening {
+            unlisten()
+        }
+
+        let clientData = Unmanaged.passUnretained(self).toOpaque()
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertySelectorWildcard,
+            mScope: kAudioObjectPropertyScopeWildcard,
+            mElement: kAudioObjectPropertyElementWildcard
+        )
+
+        if noErr == AudioObjectAddPropertyListener(id, &address, onAudioPropertyChanged, clientData) {
+            listening = true
+        }
+    }
+
+    func unlisten() {
+        if !listening {
+            return
+        }
+
+        let clientData = Unmanaged.passUnretained(self).toOpaque()
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertySelectorWildcard,
+            mScope: kAudioObjectPropertyScopeWildcard,
+            mElement: kAudioObjectPropertyElementWildcard
+        )
+
+        if noErr == AudioObjectRemovePropertyListener(id, &address, onAudioPropertyChanged, clientData) {
+            listening = false
+        }
+    }
+
+    private func validAddress(selector: AudioObjectPropertySelector) -> AudioObjectPropertyAddress? {
+        var address = AudioDevice.address(selector: selector)
+        guard AudioObjectHasProperty(id, &address) else { return nil }
+        return address
+    }
+
+    private func getProperty<T>(address: AudioObjectPropertyAddress, defaultValue: T) -> T? {
+        var value = defaultValue
+        return AudioDevice.getPropertyDataOrNil(id, address: address, andValue: &value)
+    }
+}
+
+extension AudioDevice: CustomStringConvertible {
+    public var description: String {
+        return "AudioDevice(id: \(id))"
+    }
+}
+
+extension AudioDevice {
+    class func address(selector: AudioObjectPropertySelector) -> AudioObjectPropertyAddress {
+        return AudioObjectPropertyAddress(mSelector: selector, mScope: kAudioObjectPropertyScopeGlobal, mElement: kAudioObjectPropertyElementMain)
+    }
+
+    class func getPropertyDataOrNil<T>(_ objectID: AudioObjectID, address: AudioObjectPropertyAddress, andValue: inout T) -> T? {
+        if noErr == getPropertyData(objectID, address: address, andValue: &andValue) {
+            print("GOT prop data")
+            return andValue
+        } else {
+            print("Err getting property data")
+            return nil
+        }
+    }
+
+    private class func getPropertyData<T>(_ objectID: AudioObjectID, address: AudioObjectPropertyAddress, andValue: inout T) -> OSStatus {
+        var refableAddress = address
+        var size = UInt32(MemoryLayout<T>.size)
+        let status = AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &refableAddress, UInt32(0), nil, &size, &andValue)
+
+        if status != noErr {
+            NSLog("Err getting property data: \(String(describing: status))")
+        }
+
+        return status
+    }
+}
+
+fileprivate func onAudioPropertyChanged(
+    objectID: UInt32,
+    numInAddresses: UInt32,
+    inAddresses: UnsafePointer<AudioObjectPropertyAddress>,
+    clientData: Optional<UnsafeMutableRawPointer>
+) -> Int32 {
+    let address = inAddresses.pointee
+    let _self = Unmanaged<AudioDevice>.fromOpaque(clientData!).takeUnretainedValue()
+
+    switch address.mSelector {
+        case kAudioDevicePropertyNominalSampleRate:
+            NSLog("\(_self): Nominal Sample Rate changed -> \(String(describing: _self.nominalSampleRate))!")
+
+        case kAudioDevicePropertyAvailableNominalSampleRates:
+            // TODO Fetching *available* rates is... tricky.
+            NSLog("\(_self): Available Sample Rates changed -> \(String(describing: _self.nominalSampleRate))!")
+
+
+        default:
+            break // nop
+    }
+
+    return kAudioHardwareNoError
+}

--- a/macos/gakki/gakki/Devices/AudioDeviceManager.swift
+++ b/macos/gakki/gakki/Devices/AudioDeviceManager.swift
@@ -55,9 +55,13 @@ class AudioDeviceManager {
 
     fileprivate func onDefaultDeviceChanged() {
         let newDefault = getDefaultOutputDevice()
+        let isFirst = self.defaultOutputDevice == nil
         self.defaultOutputDevice = newDefault
 
-        NSLog("CHANGE: DefaultOutputDevice \(String(describing: newDefault)) @ \(String(describing: newDefault?.nominalSampleRate))")
+        if !isFirst {
+            IPC.send(["type": "default-device-changed"])
+        }
+
         if let device = newDefault {
             device.listen()
         }

--- a/macos/gakki/gakki/Devices/AudioDeviceManager.swift
+++ b/macos/gakki/gakki/Devices/AudioDeviceManager.swift
@@ -93,7 +93,6 @@ fileprivate func onAudioPropertyChanged(
             _self.onDefaultDeviceChanged()
 
         case kAudioHardwarePropertyDefaultSystemOutputDevice:
-            /* NSLog("CHANGE: DefaultSystemOutputDevice") */
             break // nop?
         default:
             break // nop

--- a/macos/gakki/gakki/Devices/AudioDeviceManager.swift
+++ b/macos/gakki/gakki/Devices/AudioDeviceManager.swift
@@ -1,0 +1,99 @@
+//
+//  AudioDeviceManager.swift
+//  gakki
+//
+//  Created by Daniel Leong on 3/10/22.
+//
+
+import CoreAudio
+import Foundation
+
+class AudioDeviceManager {
+    private var listening = false
+
+    var defaultOutputDevice: AudioDevice? = nil
+
+    func listen() {
+        if (listening) {
+            unlisten()
+        }
+
+        let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
+        let clientData = Unmanaged.passUnretained(self).toOpaque()
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertySelectorWildcard,
+            mScope: kAudioObjectPropertyScopeWildcard,
+            mElement: kAudioObjectPropertyElementWildcard
+        )
+        if noErr == AudioObjectAddPropertyListener(systemObjectID, &address, onAudioPropertyChanged, clientData) {
+            listening = true
+        }
+
+        if defaultOutputDevice == nil {
+            // Grab and listen to the current default, if any
+            onDefaultDeviceChanged()
+        }
+    }
+
+    func unlisten() {
+        if !listening {
+            return
+        }
+
+        let systemObjectID = AudioObjectID(kAudioObjectSystemObject)
+        let clientData = Unmanaged.passUnretained(self).toOpaque()
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioObjectPropertySelectorWildcard,
+            mScope: kAudioObjectPropertyScopeWildcard,
+            mElement: kAudioObjectPropertyElementWildcard
+        )
+
+        if noErr == AudioObjectRemovePropertyListener(systemObjectID, &address, onAudioPropertyChanged, clientData) {
+            listening = false
+        }
+    }
+
+    fileprivate func onDefaultDeviceChanged() {
+        let newDefault = getDefaultOutputDevice()
+        self.defaultOutputDevice = newDefault
+
+        NSLog("CHANGE: DefaultOutputDevice \(String(describing: newDefault)) @ \(String(describing: newDefault?.nominalSampleRate))")
+        if let device = newDefault {
+            device.listen()
+        }
+    }
+
+    private func getDefaultOutputDevice() -> AudioDevice? {
+        let address = AudioDevice.address(selector: kAudioHardwarePropertyDefaultOutputDevice)
+        var deviceID = AudioDeviceID()
+
+        guard let id = AudioDevice.getPropertyDataOrNil(AudioObjectID(kAudioObjectSystemObject), address: address, andValue: &deviceID) else {
+            return nil
+        }
+
+        return AudioDevice(withID: id)
+    }
+}
+
+fileprivate func onAudioPropertyChanged(
+    objectID: UInt32,
+    numInAddresses: UInt32,
+    inAddresses: UnsafePointer<AudioObjectPropertyAddress>,
+    clientData: Optional<UnsafeMutableRawPointer>
+) -> Int32 {
+    let address = inAddresses.pointee
+    let _self = Unmanaged<AudioDeviceManager>.fromOpaque(clientData!).takeUnretainedValue()
+
+    switch address.mSelector {
+        case kAudioHardwarePropertyDefaultOutputDevice:
+            _self.onDefaultDeviceChanged()
+
+        case kAudioHardwarePropertyDefaultSystemOutputDevice:
+            /* NSLog("CHANGE: DefaultSystemOutputDevice") */
+            break // nop?
+        default:
+            break // nop
+    }
+
+    return kAudioHardwareNoError
+}

--- a/src/core/gakki/fx.cljs
+++ b/src/core/gakki/fx.cljs
@@ -206,6 +206,7 @@
 
 ; ======= Player ==========================================
 
+(reg-fx :player/check-output-device! player/check-output-device!)
 (reg-fx :player/pause! player/pause!)
 (reg-fx :player/play! player/play!)
 (reg-fx :player/prepare! player/prepare!)

--- a/src/core/gakki/native/macos.cljs
+++ b/src/core/gakki/native/macos.cljs
@@ -59,6 +59,9 @@
     :log ((log/of :native) (:message message))
     :media (handle-media-event message)
 
+    :default-device-changed (>evt [:player/check-output-device])
+    :default-device-updated (>evt [:player/check-output-device])
+
     :auth-result (swap! requests update :auth
                         (fn on-auth [handler]
                           (when handler

--- a/src/core/gakki/player.cljs
+++ b/src/core/gakki/player.cljs
@@ -105,6 +105,14 @@
 (defn set-volume! [volume-percent]
   (on-playable player/set-volume volume-percent))
 
+(defn check-output-device! []
+  (on-playable (fn [playable]
+                 (log/debug "checking output device...")
+                 (when-not (clip/default-output-device? playable)
+                   (log/debug "restart!")
+                   (player/pause playable)
+                   (player/play playable)))))
+
 (comment
   (prepare! {:item {:id "8FV4gcs-MNA"
                     :provider :ytm}})

--- a/src/core/gakki/player/track/core.cljs
+++ b/src/core/gakki/player/track/core.cljs
@@ -101,6 +101,10 @@
       (clip/current-time clip)
       0))
 
+  (default-output-device? [_this]
+    (when-let [clip (:clip @state)]
+      (clip/default-output-device? clip)))
+
   (playing? [_this]
     (if-let [clip (:clip @state)]
       (clip/playing? clip)


### PR DESCRIPTION
This PR adds some code to the native module on macOS that will detect and notify about changes to audio devices, so we can avoid audio becoming garbled when sample rates or available channels change!